### PR TITLE
Add comprehensive documentation: architecture, protocols, pinout, realtime, testing, and agent rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# ElektroCaster Agent Rules
+
+## Project summary
+
+ElektroCaster is a complex hardware/firmware project for a partially 3D-printed electric guitar with a LED fretboard, touch-sensitive fretboard sensing, Kickup solenoid actuators, a MulEBow electromagnetic actuator, hexaphonic audio processing, many body controls, and an OLED display.
+
+The project uses three microcontrollers:
+
+- `software/firmwareHid`: Teensy 3.5 firmware for body controls and the OLED display.
+- `software/firmwareCtl`: Teensy 4.1 main controller firmware for system state, LED fretboard, fretboard sensing, actuators, sequencers, MIDI, SD song storage, and board coordination.
+- `software/firmwareAudio`: Teensy 4.1 audio firmware using the Teensy Audio Library for hexaphonic DSP and actuator audio/control outputs.
+
+## Mandatory rules for future agent tasks
+
+- Do not change pin assignments unless the user explicitly asks for that change.
+- Do not change serial protocols, command IDs, payload formats, baud rates, or scaling unless the user explicitly asks for that change.
+- Do not change realtime audio code, `AudioConnection` setup, or audio routing unless the user explicitly asks for that change.
+- Do not change fretboard scanning, debounce thresholds, clock timing, or Kickup timing unless the user explicitly asks for that change.
+- Refactoring tasks must be behavior-preserving unless the user explicitly requests behavior changes.
+- Prefer small, reviewable pull requests over broad rewrites.
+- Document uncertainty instead of inventing hardware details or protocol semantics.
+- Do not edit `.ino`, `.cpp`, or `.h` files for documentation-only tasks.
+- In every final response, list affected files and checks that were not run.
+
+## Recommended workflow
+
+1. Read this file before modifying files in this repository.
+2. Check `docs/architecture.md`, `docs/protocols.md`, `docs/testing.md`, and, when present, `docs/pinout.md` and `docs/realtime.md` before touching firmware.
+3. Preserve existing behavior first; document suggested logic changes separately if they are outside the requested scope.
+4. For firmware changes, identify the affected board, serial links, pins, realtime timing, and hardware tests before implementation.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,130 @@
+# ElektroCaster architecture
+
+This document summarizes the firmware architecture as currently inferable from the repository. It is documentation only and does not define new behavior.
+
+## System overview
+
+ElektroCaster is a hardware/firmware electric guitar platform with:
+
+- a 150-pixel LED fretboard,
+- touch-sensitive fretboard detection through string/fret contacts,
+- Kickup solenoid string actuators,
+- a MulEBow electromagnetic sustain actuator,
+- hexaphonic pickup/audio processing,
+- many body controls,
+- an OLED display.
+
+The firmware is split across three microcontrollers.
+
+## Microcontroller roles
+
+### `software/firmwareHid`
+
+Likely target: Teensy 3.5.
+
+Responsibilities:
+
+- Read body controls:
+  - 22 analog inputs,
+  - 19 digital inputs,
+  - 8 encoders are instantiated in code, although `nEnc` is currently `7`, which should be treated as an open inconsistency until verified on hardware,
+  - 3 analog resistor-ladder rotary switch values.
+- Send changed control values to `firmwareCtl` over a serial link.
+- Own the OLED display hardware through U8g2.
+- Receive display drawing commands from `firmwareCtl` using AsciiMassage packets and render them locally.
+
+Important files:
+
+- `software/firmwareHid/firmwareHid.ino`: pin arrays, encoder instances, input scanning loop, display initialization.
+- `software/firmwareHid/send.ino`: HID-to-CTL byte protocol.
+- `software/firmwareHid/receive.ino`: CTL-to-HID display command receiver.
+- `software/firmwareHid/display.ino`: local U8g2 drawing helpers.
+
+### `software/firmwareCtl`
+
+Likely target: Teensy 4.1.
+
+Responsibilities:
+
+- Main system state.
+- LED fretboard control through FastLED/WS2812Serial.
+- Fretboard contact scanning and debouncing.
+- Kickup cueing and solenoid timing.
+- MulEBow control messages sent to the audio board.
+- Sequencer, scale, string setup, song, and pattern state.
+- SD card song loading/saving.
+- USB MIDI and hardware MIDI handling.
+- Serial coordination with HID and Audio boards.
+
+Important files:
+
+- `software/firmwareCtl/firmwareCtl.ino`: large global state block, setup, main loop, hardware initialization.
+- `software/firmwareCtl/04_hid.ino`: fretboard scan/debounce plus HID processing and musical actions.
+- `software/firmwareCtl/2audio.ino`: CTL-to-Audio command senders.
+- `software/firmwareCtl/13_serialEvents.ino`: serial receivers from Audio and HID.
+- `software/firmwareCtl/01_actuators.ino`: Kickup cueing and pulse handling.
+- `software/firmwareCtl/02_clock.ino`: internal clock, MIDI clock, sync points, pattern scheduling.
+- `software/firmwareCtl/03_display.ino`: display update and drawing command senders.
+- `software/firmwareCtl/05_ledfrets.ino`: LED fretboard update logic.
+- `software/firmwareCtl/14_song.ino`: binary SD song save/load format.
+
+### `software/firmwareAudio`
+
+Likely target: Teensy 4.1.
+
+Responsibilities:
+
+- Hexaphonic audio input and processing using the Teensy Audio Library.
+- TDM audio input and output through `AudioInputTDM`, `AudioOutputTDM`, and `AudioControlCS42448`.
+- Per-string input gain, envelope, filter, ring/amplitude modulation, pitch analysis, RMS analysis.
+- MulEBow/coil oscillator outputs.
+- Receive control commands from `firmwareCtl`.
+- Send pitch and amplitude analysis data back to `firmwareCtl`.
+
+Important files:
+
+- `software/firmwareAudio/firmwareAudio.ino`: global audio objects, state, static output summing connections.
+- `software/firmwareAudio/0Setup.ino`: audio hardware setup and per-string `AudioConnection` construction.
+- `software/firmwareAudio/yLoop.ino`: serial command parser, analysis loop, MulEBow state handling.
+- `software/firmwareAudio/2ctl.ino`: Audio-to-CTL status senders.
+- `software/firmwareAudio/envelopes.ino`, `filter.ino`, `fx.ino`, `lfos.ino`: DSP parameter helpers.
+
+## Data flow
+
+```text
+Body controls + OLED hardware
+        |
+        | firmwareHid Serial6 @ 115200 baud
+        v
+firmwareCtl Serial7 @ 115200 baud
+        |
+        | firmwareCtl Serial1 @ 250000 baud
+        v
+firmwareAudio Serial1 @ 250000 baud
+```
+
+Additional flows:
+
+- `firmwareCtl` sends display drawing commands to `firmwareHid` using AsciiMassage packets.
+- `firmwareHid` sends HID control changes to `firmwareCtl` using compact byte messages.
+- `firmwareCtl` sends audio control, string state, envelope, filter, volume, and bow commands to `firmwareAudio` using compact byte messages.
+- `firmwareAudio` sends pitch and amplitude estimates back to `firmwareCtl`.
+- `firmwareCtl` also handles USB MIDI and hardware MIDI.
+
+## Known technical risks
+
+- Many global variables in `firmwareCtl` and `firmwareAudio` make dependencies implicit.
+- Several files mix hardware access, state updates, UI handling, musical logic, and protocol handling.
+- Pin assignments and hardware mappings are embedded directly in firmware files.
+- Serial protocols use magic byte values and do not appear to have checksums, versioning, or documented recovery behavior.
+- Several serial parsers use blocking `while(Serial.available() == 0)` waits, which can hang if bytes are lost or boards reset mid-message.
+- `firmwareCtl/04_hid.ino` couples fretboard scanning, debounce, MIDI, Kickup, audio triggering, and sequencer editing.
+- `firmwareCtl/02_clock.ino` calls display updates from the internal clock path; timing impacts should be measured before changing it.
+- `firmwareAudio/0Setup.ino` builds many audio connections dynamically; audio routing changes are high risk.
+- `firmwareCtl/14_song.ino` stores song data as an implicit binary layout without an evident version header.
+
+## Refactor safety guidance
+
+- Documentation-only changes should not touch firmware source files.
+- For firmware refactors, start by naming constants and documenting existing behavior before changing control flow.
+- Treat pin mappings, serial payloads, audio routing, Fretboard scan timing, Clock timing, and Kickup pulse timing as protected behavior.

--- a/docs/pinout.md
+++ b/docs/pinout.md
@@ -1,0 +1,135 @@
+# ElektroCaster pinout notes
+
+This document records pin assignments inferable from firmware source. It does not change pin values. Hardware labels and board connector names are open unless explicitly shown in code.
+
+## `software/firmwareHid`
+
+### Encoders
+
+| Encoder | Pins |
+| --- | --- |
+| `enc0` | `16`, `15` |
+| `enc1` | `3`, `2` |
+| `enc2` | `6`, `5` |
+| `enc3` | `9`, `8` |
+| `enc4` | `12`, `11` |
+| `enc5` | `26`, `24` |
+| `enc6` | `29`, `28` |
+| `enc7` | `45`, `44` |
+
+Open: `nEnc` is declared as `7` while eight encoders are instantiated and sent.
+
+### Analog inputs
+
+`aPin[22]`:
+
+| Index | Pin | Notes |
+| ---: | --- | --- |
+| 0 | `31` | Analog control; exact hardware function open. |
+| 1 | `32` | Analog control; exact hardware function open. |
+| 2 | `33` | Analog control; exact hardware function open. |
+| 3 | `34` | Analog control; exact hardware function open. |
+| 4 | `35` | Analog control; exact hardware function open. |
+| 5 | `36` | Analog control; exact hardware function open. |
+| 6 | `37` | Analog control; exact hardware function open. |
+| 7 | `38` | Analog control; exact hardware function open. |
+| 8 | `39` | Analog control; exact hardware function open. |
+| 9 | `A21` | Analog control; exact hardware function open. |
+| 10 | `A22` | Analog control; exact hardware function open. |
+| 11 | `14` | Analog control; exact hardware function open. |
+| 12 | `A26` | Analog control; exact hardware function open. |
+| 13 | `A25` | Analog control; exact hardware function open. |
+| 14 | `A11` | Analog control; exact hardware function open. |
+| 15 | `A10` | Analog control; exact hardware function open. |
+| 16 | `A24` | Analog control; exact hardware function open. |
+| 17 | `A23` | Analog control; exact hardware function open. |
+| 18 | `A9` | Analog control; exact hardware function open. |
+| 19 | `A8` | Rotary switch resistor ladder input. |
+| 20 | `A7` | Rotary switch resistor ladder input. |
+| 21 | `A6` | Rotary switch resistor ladder input. |
+
+### Digital inputs
+
+`dPin[19]`:
+
+| Index | Pin | Notes |
+| ---: | --- | --- |
+| 0 | `17` | Digital control; exact hardware function open. |
+| 1 | `13` | Digital control; exact hardware function open. |
+| 2 | `51` | Digital control; exact hardware function open. |
+| 3 | `52` | Digital control; exact hardware function open. |
+| 4 | `53` | Digital control; exact hardware function open. |
+| 5 | `42` | Digital control; exact hardware function open. |
+| 6 | `41` | Digital control; exact hardware function open. |
+| 7 | `40` | Digital control; exact hardware function open. |
+| 8 | `56` | Digital control; exact hardware function open. |
+| 9 | `57` | Digital control; exact hardware function open. |
+| 10 | `43` | Digital control; exact hardware function open. |
+| 11 | `54` | Digital control; exact hardware function open. |
+| 12 | `55` | Digital control; exact hardware function open. |
+| 13 | `4` | Digital control; exact hardware function open. |
+| 14 | `7` | Digital control; exact hardware function open. |
+| 15 | `10` | Digital control; exact hardware function open. |
+| 16 | `25` | Digital control; exact hardware function open. |
+| 17 | `27` | Digital control; exact hardware function open. |
+| 18 | `30` | Digital control; exact hardware function open. |
+
+## `software/firmwareCtl`
+
+### Serial ports
+
+| Port | Baud | Inferred use |
+| --- | ---: | --- |
+| `Serial` | 115200 | Debug USB serial. |
+| `Serial1` | 250000 | Audio board link. |
+| `Serial7` | 115200 | HID board link. |
+| `Serial8` | MIDI library instance | Hardware MIDI. |
+
+### LED fretboard
+
+| Symbol | Value | Notes |
+| --- | --- | --- |
+| `LED_PIN` | `14` | WS2812Serial/FastLED data pin. |
+| `NUMPIXELS` | `150` | Total LED count. |
+| `nLedFrets` | `25` | LED fret positions per string. |
+
+The physical LED matrix mapping is encoded in `led_pixPos[6][25]`. Exact physical orientation should be verified against hardware.
+
+### Fretboard contact sensing
+
+| Symbol | Values | Notes |
+| --- | --- | --- |
+| `nFrets` | `21` | Fret contact count used for scanning. |
+| `frtPins` | `{13,33,2,3,4,5,6,7,8,9,10,11,12,24,25,26,27,30,31,32,17,16}` | Contains 22 entries while `nFrets` is 21; open issue to verify. |
+| `strPins` | `{18,19,20,21,22,23}` | Six string sense inputs. |
+
+Open: `strSnsPins` is also declared as `{2,3,4,5,6,7}` in the string definitions section, but the fretboard scanner uses `strPins`.
+
+### Kickup
+
+| String index | Pin |
+| ---: | ---: |
+| 0 | `41` |
+| 1 | `40` |
+| 2 | `39` |
+| 3 | `38` |
+| 4 | `37` |
+| 5 | `36` |
+
+## `software/firmwareAudio`
+
+### Serial ports
+
+| Port | Baud | Inferred use |
+| --- | ---: | --- |
+| `Serial` | 115200 | Debug USB serial. |
+| `Serial1` | 250000 | CTL board link. |
+
+### TDM audio channel mappings
+
+| Array | Values | Notes |
+| --- | --- | --- |
+| `strAIn[6]` | `{10,8,6,4,2,0}` | Audio input channels of the strings. |
+| `strAOut[6]` | `{10,8,6,4,2,0}` | Output channels of the string coils. |
+
+Open: Physical codec channel labels and connector wiring are not documented in source.

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -1,0 +1,137 @@
+# ElektroCaster serial protocols
+
+This document records currently observed serial protocols. It is based on repository source code only. Where semantics are unclear, they are marked as open.
+
+## Serial links and baud rates
+
+| Link | Sender-side port | Receiver-side port | Baud | Notes |
+| --- | --- | --- | --- | --- |
+| HID -> CTL | `firmwareHid` `Serial6` | `firmwareCtl` `Serial7` | 115200 | HID controls to main controller. |
+| CTL -> HID display | `firmwareCtl` `Serial7` | `firmwareHid` `Serial6` | 115200 | AsciiMassage display drawing commands. Same physical link is likely bidirectional. |
+| CTL -> Audio | `firmwareCtl` `Serial1` | `firmwareAudio` `Serial1` | 250000 | Raw byte command protocol. |
+| Audio -> CTL | `firmwareAudio` `Serial1` | `firmwareCtl` `Serial1` | 250000 | Raw byte status protocol. Same physical link is likely bidirectional. |
+
+Open question: physical wiring and electrical directionality are not documented in the repository.
+
+## HID -> CTL protocol
+
+Implemented in:
+
+- `software/firmwareHid/send.ino`
+- `software/firmwareCtl/13_serialEvents.ino`
+
+General form: a command/index byte followed by one value byte. HID also emits `255` as a frame/end marker; CTL currently has a commented reference to it but no active handling was identified.
+
+Constants inferred from code:
+
+- `nDigital = 19`
+- `nAnalog = 22`
+- Rotary switch analog source indices are `19..21`, sent separately as rotary states instead of normal analog values.
+
+| HID data type | Sender command byte | CTL decoded range | Payload | Value range / scaling |
+| --- | --- | --- | --- | --- |
+| Digital input | `idx + 201` | `incoming < 19` | 1 byte `val` | Raw digital state. |
+| Analog input | `idx + nDigital + 201` | `incoming >= 19 && incoming < 38` | 1 byte `val` | `analogRead` mapped from `0..1023` to `0..200`; indices `19..21` are excluded. |
+| Rotary switch | `idx + nDigital + 19 + 201` | `incoming >= 38 && incoming < 41` | 1 byte `val` | Rotary state index, likely `0..11`. |
+| Encoder delta | `idx + nDigital + 22 + 201` | `incoming >= 41 && incoming < 49` | 1 byte `val` | Delta encoded as `delta + 100`; CTL subtracts `100`. |
+| Frame/end marker | `255` | Not actively handled | none | Sent by HID after `sendAllNew()`. Semantics open. |
+
+Open/incomplete:
+
+- There are 8 `Encoder` instances but `nEnc` is declared as `7`; protocol range supports 8 encoder indices `0..7` through decoded values `41..48`.
+- No checksum, timeout, or sequence number was identified.
+- CTL blocks waiting for value bytes after receiving a recognized command byte.
+
+## CTL -> HID display protocol
+
+Implemented in:
+
+- `software/firmwareCtl/03_display.ino`
+- `software/firmwareHid/receive.ino`
+
+Transport: AsciiMassage packets over the CTL/HID serial link.
+
+Known packet names and payloads:
+
+| Packet | Payload | Meaning |
+| --- | --- | --- |
+| `str` | `byte x`, `byte y`, `string text` | Draw string. |
+| `int` | `byte x`, `byte y`, `int val` | Draw integer. |
+| `lng` | `byte x`, `byte y`, `long val` | Draw long integer. |
+| `frm` | `byte xp`, `byte yp`, `byte xs`, `byte ys` | Draw frame. |
+| `box` | `byte xp`, `byte yp`, `byte xs`, `byte ys` | Draw box. |
+| `rfr` | `byte xp`, `byte yp`, `byte xs`, `byte ys`, `byte r` | Draw rounded frame. |
+| `rbx` | `byte xp`, `byte yp`, `byte xs`, `byte ys`, `byte r` | Draw rounded box. |
+| `cir` | `byte x`, `byte y`, `byte r` | Draw circle. |
+| `dis` | `byte x`, `byte y`, `byte r` | Draw filled disc. |
+| `pix` | `byte x`, `byte y` | Draw pixel. |
+| `col` | `byte c` | Set draw color. |
+| `lin` | `byte x0`, `byte y0`, `byte x1`, `byte y1` | Draw line. |
+| `clr` | none | Clear buffer. |
+| `buf` | none | Send buffer to display. |
+| `tuner` | open | Handler is present but commented out. |
+
+Open/incomplete:
+
+- Coordinate and color ranges are not formally documented; likely U8g2 display coordinates for a 128x64 OLED.
+- Error handling for malformed packets is delegated to AsciiMassage behavior.
+
+## CTL -> Audio protocol
+
+Implemented in:
+
+- `software/firmwareCtl/2audio.ino`
+- `software/firmwareAudio/yLoop.ino`
+
+General form: first byte is a command ID in the range `200..255`. Audio computes `incoming = command - 200`. Payload length depends on command.
+
+Known command IDs:
+
+| Command byte | Audio `incoming` | Sender function | Payload | Observed receiver behavior / scaling |
+| --- | ---: | --- | --- | --- |
+| `200` | `0` | `sndTrigEnv(str, vel)` | `byte str`, `byte velocity` | Audio calls `trigEnv(str, velocity / 199.0)`. |
+| `201` | `1` | `sndStrPrs(str, pitch, state)` | `byte str`, `byte pitch`, `byte state` | Audio calls `strFret(str, pitch, state)` and stores `strState[str] = state`. |
+| `202` | `2` | not found in CTL sender file | one byte | Audio calls `chOpMode(data)` when byte `<=199`. Source uncertain. |
+| `203` | `3` | not found in CTL sender file | one byte | Audio calls `chDispMode(data)` when byte `<=199`. Source uncertain. |
+| `204` | `4` | not found in CTL sender file | one byte | Audio calls `chKickMode(data)` when byte `<=199`. Source uncertain. |
+| `205` | `5` | `sndBowMode(mode)` | `byte mode` | Audio calls `chBowMode(mode)` when byte `<=199`. Note: Audio-to-CTL CC also uses byte `205` in another direction. |
+| `206` | `6` | `sndBowOn(mode)` | `byte mode` | Audio sets `bowOn = mode` when byte `<=199`. Note: Audio-to-CTL pitch also uses byte `206` in reverse direction. |
+| `207` | `7` | `sndEnv1(para, val)` | `byte para`, `byte scaledVal` | Audio scales `scaledVal / 199.0` with `sclEnvA[para]`, calls `chEnvA`. |
+| `208` | `8` | `sndEnv2(para, val)` | `byte para`, `byte scaledVal` | Audio scales `scaledVal / 199.0` with `sclEnvF[para]`, calls `chEnvF`. |
+| `209` | `9` | `sndFilter(para, val)` | `byte para`, `byte scaledVal` | Audio scales with `sclFilter[para]`, calls `chFilter`. |
+| `211` | `11` | `sndVol(val)` | `byte scaledVal` | Audio computes `(scaledVal / 199.0)^2 * 2`, then `ampOut.gain(val + 0.0001)`. |
+| `212` | `12` | `sndStrGain(str, val)` | `byte str`, `byte scaledVal` | Audio computes `scaledVal / 100.0`, calls `chngStrOutGain`. CTL sends `val * 2`. |
+| `215` | `15` | not found in CTL sender file | `byte para`, `byte scaledVal` | Audio scales with `sclFX[para]`, calls `chFX`. Source uncertain. |
+| `216` | `16` | `sndLfo1(para, val)` | `byte para`, `byte scaledVal` | Audio scales with `sclLfo1[para]`, applies `chLfo1` to all strings. |
+| `217` | `17` | not found in CTL sender file | one byte | Audio stores BPM byte. Source uncertain. |
+| `218` | `18` | not found in CTL sender file | `byte a`, `byte b` | Audio sends MIDI CC `3, b/2` only if `a == 2`. Source uncertain. |
+
+Open/incomplete:
+
+- Commands `202`, `203`, `204`, `215`, `217`, and `218` are handled by Audio but corresponding CTL sender functions were not identified in `2audio.ino`.
+- Blocking reads are used for payload bytes.
+- No checksum, version, length byte, escaping, or resynchronization strategy was identified.
+- Values above `199` are treated as command bytes, so payload values should remain `<=199` unless explicitly safe.
+
+## Audio -> CTL protocol
+
+Implemented in:
+
+- `software/firmwareAudio/2ctl.ino`
+- `software/firmwareCtl/13_serialEvents.ino`
+
+General form: first byte is a command ID, CTL computes `incoming = command - 200`.
+
+Known command IDs:
+
+| Command byte | CTL `incoming` | Sender function | Payload | CTL receiver behavior |
+| --- | ---: | --- | --- | --- |
+| `201` | `1` | `sndNote(pitch, vel)` | `byte pitch`, `byte vel` | No active CTL receiver case was identified for `incoming == 1` in `13_serialEvents.ino`; source/receiver semantics open. |
+| `205` | `5` | `sndCC()` | `byte cc`, `byte val` | No active CTL receiver case was identified for `incoming == 5` in `13_serialEvents.ino`; source/receiver semantics open. |
+| `206` | `6` | `sndStrP()` | `byte string`, `byte integerPart`, `byte fractionalPart` | CTL stores `strP[string] = integerPart + fractionalPart / 100.0`. |
+| `207` | `7` | `sndStrA()` | `byte string`, `byte amplitudePercent` | CTL stores `strA[string] = amplitudePercent / 100.0`. |
+
+Open/incomplete:
+
+- Audio sender functions for note/CC appear to exist, but CTL receiver handling was not identified in the inspected serial event file.
+- Same numeric command IDs are reused in opposite directions, which is acceptable on a bidirectional link only if direction is always clear.

--- a/docs/realtime.md
+++ b/docs/realtime.md
@@ -1,0 +1,98 @@
+# ElektroCaster realtime and timing notes
+
+This document records timing values inferable from firmware source. It does not change timing behavior.
+
+## `software/firmwareCtl`
+
+### LED fretboard
+
+| Symbol | Value | Meaning |
+| --- | ---: | --- |
+| `fled_frameInt` | `50` ms | LED fretboard frame/update interval. |
+
+### Fretboard scanning and debounce
+
+| Symbol | Value | Meaning |
+| --- | ---: | --- |
+| `fretMaskT` | `50` ms | Minimum time before another string press on the same string is detected. |
+| `strBncs` | `500` samples | Same-sample count threshold for normal string press detection. |
+| `strBncsP` | `5000` samples | Same-sample count threshold intended for pattern section detection; related code appears commented/disabled. |
+
+Notes:
+
+- `readFretboard()` is called from the main loop.
+- The scanner switches fret pins between output/input modes depending on sensing mode.
+- Fretboard scan behavior is protected and should not be changed without explicit request and hardware tests.
+
+### Kickup timing
+
+| Symbol | Value | Meaning |
+| --- | ---: | --- |
+| `kickDur[6]` | `{5,5,5,5,5,5}` ms | Pulse duration per string. |
+| `kCueInt` | `3` ms | Interval used to stagger queued kicks. |
+
+Notes:
+
+- `cueKicks()` calls `kickOff()` and then triggers at most one queued string per cue interval.
+- This likely prevents simultaneous solenoid current spikes.
+
+### Display update
+
+| Symbol | Value | Meaning |
+| --- | ---: | --- |
+| `disp_frameInt` | `200` ms | Display update interval. |
+
+Note: `updDisplay()` is currently called from `updIntClock()`, so display refresh is coupled to internal clock processing when `extClk == 0`.
+
+### Clock timing
+
+| Item | Value / formula | Meaning |
+| --- | --- | --- |
+| Internal PPQN basis | `24` | `bpm2Micros()` divides by 24. |
+| `bpm2Micros(val)` | `60000000 / val / 24` | Microseconds per MIDI-clock-style tick. |
+| `bpm2Millis(val)` | `60000 / val / 24` | Milliseconds equivalent; comment says microseconds but function name says millis. |
+| Default `bpm` | `90` | Main controller default BPM. |
+
+Clock-derived state:
+
+- `pulse = mClock / 24`
+- `bar = mClock / 96`
+- `syncPnt = mClock / syncInt`
+
+Open: `syncInt` initialization should be verified before any clock refactor.
+
+## `software/firmwareHid`
+
+| Symbol / call | Value | Meaning |
+| --- | ---: | --- |
+| `waitS` | `50` microseconds | Delay inserted between HID protocol bytes. |
+| `analogReadAveraging(200)` | `200` samples | Analog input averaging setting. |
+| startup display delay | `2000` ms | Delay after `u8g2.begin()`. |
+
+## `software/firmwareAudio`
+
+| Symbol | Value | Meaning |
+| --- | ---: | --- |
+| `ctlInt` | `10` ms | Control loop interval placeholder/check interval. |
+| `nFrqInt` | `20` ms | Pitch analysis/send interval. |
+| `peakInt` | `20` ms | RMS/amplitude analysis/send interval. |
+| `waitS` | `100` microseconds | Delay used between bytes in some Audio-to-CTL senders. |
+| `AudioMemory` | `2000` blocks | Teensy Audio memory allocation. |
+| setup delay | `1000` ms | Delay before audio initialization. |
+
+Notes:
+
+- Pitch analysis resumes/checks all six `AudioAnalyzeMonoFrequency` instances every `nFrqInt` interval.
+- RMS analysis checks all six `AudioAnalyzeRMS` instances every `peakInt` interval.
+- Debug processor/memory usage printing exists but is disabled behind `if(0)`.
+
+## Protected timing areas
+
+Do not change these without explicit user instruction and hardware validation:
+
+- LED frame interval and LED update path.
+- Fretboard pin scanning mode, debounce counters, and mask time.
+- Kickup pulse duration and queue interval.
+- Internal clock tick calculation and pattern sync behavior.
+- Audio analysis intervals and Audio Library routing.
+- Serial byte spacing unless the protocol is intentionally redesigned.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,188 @@
+# ElektroCaster testing guide
+
+This guide lists manual and lightweight checks to run before and after refactors. Most functional tests require the physical ElektroCaster hardware.
+
+## General pre-refactor checklist
+
+1. Confirm the intended board(s): HID, CTL, Audio, or documentation only.
+2. Record the current branch and `git status`.
+3. Identify whether the change touches protected areas:
+   - pin mappings,
+   - serial protocols,
+   - Audio Library routing or `AudioConnection`s,
+   - fretboard scanning/debounce,
+   - clock timing,
+   - Kickup timing.
+4. If protected behavior is touched, define an explicit hardware test plan before changing code.
+5. Prefer one subsystem per pull request.
+
+## Documentation-only checks
+
+Can run without hardware:
+
+- Verify changed file list contains only intended documentation files.
+- Search for accidental firmware edits.
+- Run `git diff --stat` and inspect `git diff`.
+- Check Markdown readability manually.
+
+## HID input test
+
+Hardware required: HID board connected to CTL board or serial monitor instrumentation.
+
+Purpose: verify controls still decode correctly.
+
+Procedure:
+
+1. Power the system in a safe state with actuators disabled if possible.
+2. Move each analog control across its range.
+3. Toggle each digital switch/button.
+4. Rotate each encoder clockwise and counter-clockwise.
+5. Rotate each 12-position rotary switch through all positions.
+6. Observe decoded values on CTL debug output or display.
+
+Expected results:
+
+- Digital values change once per switch transition.
+- Analog values change smoothly and remain in the expected `0..200` transmitted range.
+- Encoder deltas have correct sign and no stuck values.
+- Rotary switch states map to stable positions, likely `0..11`.
+
+## Fretboard scan test
+
+Hardware required: CTL board connected to the fretboard/string contact matrix.
+
+Purpose: verify string/fret contact scanning, debouncing, and press/release behavior.
+
+Procedure:
+
+1. Enable a debug display or serial output for `strPrs`, `frtPrs`, and string index if available.
+2. Press and release each string at several frets including low, middle, and high positions.
+3. Test open-string release behavior.
+4. Test fast repeated presses on the same string.
+5. Test multiple simultaneous string presses.
+
+Expected results:
+
+- Pressed fret maps to the expected string and fret number.
+- Release returns to zero state.
+- No excessive double triggers.
+- Behavior is unchanged before and after a refactor.
+
+## LED fretboard test
+
+Hardware required: CTL board and LED fretboard.
+
+Purpose: verify LED mapping, colors, brightness, and frame update behavior.
+
+Procedure:
+
+1. Run a known LED mode, such as scale or grid display.
+2. Verify all 150 LEDs can light.
+3. Verify each string/fret coordinate maps to the expected physical LED.
+4. Check brightness and color compensation visually.
+5. Observe whether LED updates interfere with controls, clock, or audio.
+
+Expected results:
+
+- No missing or misaddressed LEDs.
+- No unexpected color channel swaps.
+- No visible stalls after documentation-only or behavior-neutral changes.
+
+## Kickup test
+
+Hardware required: CTL board, Kickup driver hardware, and safe test conditions.
+
+Safety note: Kickup uses solenoids and can draw significant current. Use current limiting, dummy loads, or reduced power when appropriate.
+
+Purpose: verify Kickup pulse timing and cue sequencing.
+
+Procedure:
+
+1. Disable or physically isolate strings if mechanical motion is unsafe.
+2. Trigger each string individually.
+3. Trigger multiple strings at once.
+4. Use a logic analyzer or oscilloscope on Kickup pins if available.
+5. Confirm pulse duration and inter-string cue spacing against documented values.
+
+Expected results:
+
+- Each selected string receives one pulse.
+- Multiple queued kicks are staggered rather than fired simultaneously.
+- No stuck HIGH outputs.
+
+## Audio control test
+
+Hardware required: CTL and Audio boards connected through their serial link.
+
+Purpose: verify CTL-to-Audio command decoding.
+
+Procedure:
+
+1. Send or trigger known CTL commands for envelope trigger, string press, volume, filter, envelope parameter, string gain, bow mode/on, and LFO where applicable.
+2. Observe Audio board debug output or audible behavior.
+3. Confirm no command causes serial lockup.
+4. If using debug output, keep prints minimal to avoid changing timing.
+
+Expected results:
+
+- Audio board receives correct command IDs and payloads.
+- Values remain within expected scaled ranges.
+- No blocking parser hang when commands are sent normally.
+
+## Audio I/O test
+
+Hardware required: Audio board, audio codec, hexaphonic input source or test signal, output monitoring.
+
+Purpose: verify audio routing and per-string processing.
+
+Procedure:
+
+1. Feed a known signal into each string input channel one at a time.
+2. Confirm each string path reaches the expected output/summed output.
+3. Test envelope, filter, and gain changes.
+4. Monitor processor and memory usage if debug instrumentation is enabled.
+
+Expected results:
+
+- Each input channel maps to the expected string.
+- Output routing matches pre-refactor behavior.
+- No unexpected clipping, silence, channel swap, or instability.
+
+## MulEBow test
+
+Hardware required: Audio board, coil/MulEBow actuator path, and safe actuator power setup.
+
+Purpose: verify electromagnetic sustain actuator control.
+
+Procedure:
+
+1. Start with safe actuator levels.
+2. Toggle Bow on/off from CTL controls.
+3. Press strings and observe whether coil oscillator amplitude responds only for active strings.
+4. Test bow mode changes if currently implemented in the UI.
+5. Monitor for overheating or unintended continuous drive.
+
+Expected results:
+
+- Bow off results in no coil drive.
+- Bow on drives only expected active strings.
+- No stuck actuator output after release or mode changes.
+
+## Tests possible without hardware
+
+- Documentation diff review.
+- Markdown review.
+- Static file inventory with `rg --files`.
+- Git checks: `git status --short`, `git diff --stat`, `git diff --check`.
+- Future host-side protocol encode/decode tests, if protocol code is extracted into testable modules.
+- Future song serialization tests, if SD layout is abstracted into host-testable code.
+
+## Tests requiring hardware
+
+- HID input test.
+- Fretboard scan test.
+- LED fretboard test.
+- Kickup test.
+- CTL-to-Audio and Audio-to-CTL live protocol test.
+- Audio I/O test.
+- MulEBow test.


### PR DESCRIPTION
### Motivation

- Provide a single-source set of documentation for firmware architecture, serial protocols, pin mappings, realtime/timing notes, testing guidance, and agent rules inferred from the repository. 
- Make protected areas and high-risk firmware behaviors explicit so future changes are safer and reviewable. 
- Centralize knowledge for contributors to consult before touching hardware/firmware code. 

### Description

- Add `AGENTS.md` containing mandatory agent rules and a recommended workflow for interacting with the repository. 
- Add `docs/architecture.md` summarizing the three-board firmware split, responsibilities, and important files. 
- Add `docs/protocols.md` documenting observed serial protocols between HID, CTL, and Audio including known command ranges and open questions. 
- Add `docs/pinout.md` enumerating pin assignments inferred from firmware for HID, CTL, and Audio. 
- Add `docs/realtime.md` capturing timing values and protected realtime areas for LED updates, fretboard scanning, Kickup timing, clock, and audio analysis. 
- Add `docs/testing.md` with a testing checklist and manual/hardware test procedures to validate refactors and behavior-sensitive changes. 

### Testing

- Ran lightweight documentation checks: `git diff --stat` to verify the file list and a local `markdownlint` run; both checks succeeded. 
- No firmware builds, unit tests, or hardware integration tests were executed as part of this documentation-only change. 
- Affected files: `AGENTS.md`, `docs/architecture.md`, `docs/protocols.md`, `docs/pinout.md`, `docs/realtime.md`, and `docs/testing.md`. 
- Not-run checks: firmware compile/build, hardware tests (HID input, fretboard scan, LED fretboard, Kickup, CTL<->Audio protocol exchanges, audio I/O, MulEBow), and any CI unit/integration test suites.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3251c197b08332b01201c0f1c87fe8)