### PR TITLE
Add protocol headers and replace magic command bytes with named constants

### DIFF
--- a/software/firmwareAudio/2ctl.ino
+++ b/software/firmwareAudio/2ctl.ino
@@ -1,8 +1,10 @@
+#include "ProtocolAudio.h"
+
 void sndClock(long clck){
 }
  
 void sndNote(byte pitch, byte vel){
-  Serial1.write(201);
+  Serial1.write(AUDIO_STATUS_NOTE);
   delayMicroseconds(waitS);
   Serial1.write(pitch);
   delayMicroseconds(waitS);
@@ -26,7 +28,7 @@ void sndNotes(){
 void sndCC(){
   for(byte i = 0;i<=127;i++){
     if(ccState[i]!=lastCCState[i]){
-      Serial1.write(205);
+      Serial1.write(AUDIO_STATUS_CC);
       delayMicroseconds(waitS);
       Serial1.write(i);
       delayMicroseconds(waitS);
@@ -40,7 +42,7 @@ void sndCC(){
 void sndStrP(){
   for(byte i = 0;i<nStrings;i++){
     if(strP[i]!=lastStrP[i]){
-      Serial1.write(206);
+      Serial1.write(AUDIO_STATUS_STR_PITCH);
       delayMicroseconds(waitS);
       Serial1.write(i);
       delayMicroseconds(waitS);
@@ -56,7 +58,7 @@ void sndStrP(){
 void sndStrA(){
   for(byte i = 0;i<nStrings;i++){
     if(strA[i]!=lastStrA[i]){
-      Serial1.write(207);
+      Serial1.write(AUDIO_STATUS_STR_AMPLITUDE);
       delayMicroseconds(waitS);
       Serial1.write(i);
       delayMicroseconds(waitS);

--- a/software/firmwareAudio/ProtocolAudio.h
+++ b/software/firmwareAudio/ProtocolAudio.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <Arduino.h>
+
+constexpr byte AUDIO_CMD_BASE = 200;
+constexpr byte AUDIO_CMD_MAX = 255;
+
+// CTL -> Audio command bytes.
+constexpr byte AUDIO_CMD_TRIG_ENV = 200;
+constexpr byte AUDIO_CMD_STR_FRET = 201;
+constexpr byte AUDIO_CMD_OP_MODE = 202;
+constexpr byte AUDIO_CMD_DISP_MODE = 203;
+constexpr byte AUDIO_CMD_KICK_MODE = 204;
+constexpr byte AUDIO_CMD_BOW_MODE = 205;
+constexpr byte AUDIO_CMD_BOW_ON = 206;
+constexpr byte AUDIO_CMD_ENV_1 = 207;
+constexpr byte AUDIO_CMD_ENV_2 = 208;
+constexpr byte AUDIO_CMD_FILTER = 209;
+constexpr byte AUDIO_CMD_VOLUME = 211;
+constexpr byte AUDIO_CMD_STR_GAIN = 212;
+constexpr byte AUDIO_CMD_FX = 215;
+constexpr byte AUDIO_CMD_LFO_1 = 216;
+constexpr byte AUDIO_CMD_BPM = 217;
+constexpr byte AUDIO_CMD_MIDI_CC = 218;
+
+// Audio -> CTL status command bytes.
+constexpr byte AUDIO_STATUS_NOTE = 201;
+constexpr byte AUDIO_STATUS_CC = 205;
+constexpr byte AUDIO_STATUS_STR_PITCH = 206;
+constexpr byte AUDIO_STATUS_STR_AMPLITUDE = 207;
+
+constexpr byte audioIncoming(byte command) {
+  return command - AUDIO_CMD_BASE;
+}

--- a/software/firmwareAudio/yLoop.ino
+++ b/software/firmwareAudio/yLoop.ino
@@ -1,15 +1,17 @@
+#include "ProtocolAudio.h"
+
 void serialEvent1(){
         static int incoming;
         byte sbyte = Serial1.read();
         //Serial.write(serbyte);
-        if (sbyte > 199 && sbyte <= 255) incoming = sbyte - 200;
+        if (sbyte >= AUDIO_CMD_BASE && sbyte <= AUDIO_CMD_MAX) incoming = audioIncoming(sbyte);
 
 //        if (incoming == 12) usbMIDI.sendRealTime(usbMIDI.Clock);
 //        if (incoming == 13) usbMIDI.sendRealTime(usbMIDI.Start);
 //        if (incoming == 14) usbMIDI.sendRealTime(usbMIDI.Stop);
-        //if (incoming == 17)sndNotes();
+        //if (incoming == audioIncoming(AUDIO_CMD_BPM))sndNotes();
 
-        if (incoming == 0){
+        if (incoming == audioIncoming(AUDIO_CMD_TRIG_ENV)){
           byte a;
           float b;
           while(Serial1.available() == 0);
@@ -22,7 +24,7 @@ void serialEvent1(){
           incoming = -1;
         }
          
-        if (incoming == 1){
+        if (incoming == audioIncoming(AUDIO_CMD_STR_FRET)){
           byte a;
           byte b;
           byte c;
@@ -38,7 +40,7 @@ void serialEvent1(){
           incoming = -1;
         }
 
-        if (incoming == 7){
+        if (incoming == audioIncoming(AUDIO_CMD_ENV_1)){
           byte a;
           byte b;
           while(Serial1.available() == 0);
@@ -51,7 +53,7 @@ void serialEvent1(){
           incoming = -1;
         }
 
-        if (incoming == 8){
+        if (incoming == audioIncoming(AUDIO_CMD_ENV_2)){
           byte a;
           byte b;
           while(Serial1.available() == 0);
@@ -64,7 +66,7 @@ void serialEvent1(){
           incoming = -1;
         }
 
-        if (incoming == 9){
+        if (incoming == audioIncoming(AUDIO_CMD_FILTER)){
           byte a;
           byte b;
           while(Serial1.available() == 0);
@@ -76,7 +78,7 @@ void serialEvent1(){
           incoming = -1;
         }
 
-        if (incoming == 12){
+        if (incoming == audioIncoming(AUDIO_CMD_STR_GAIN)){
            byte a;
            byte b;
            float val;
@@ -92,7 +94,7 @@ void serialEvent1(){
            incoming = -1;
           }
 
-        if (incoming == 15){
+        if (incoming == audioIncoming(AUDIO_CMD_FX)){
           byte a;
           byte b;
           while(Serial1.available() == 0);
@@ -104,7 +106,7 @@ void serialEvent1(){
           incoming = -1;
         }
 
-        if (incoming == 16){
+        if (incoming == audioIncoming(AUDIO_CMD_LFO_1)){
            byte a;
            float b;
            while(Serial1.available() == 0);
@@ -118,7 +120,7 @@ void serialEvent1(){
           incoming = -1;
           }
 
-        if (incoming == 18){
+        if (incoming == audioIncoming(AUDIO_CMD_MIDI_CC)){
            byte a;
            byte b;
            while(Serial1.available() == 0);
@@ -133,13 +135,13 @@ void serialEvent1(){
         
         if (sbyte <= 199){
                 
-          if (incoming == 2) chOpMode(sbyte),incoming = -1;
-          if (incoming == 3) chDispMode(sbyte),incoming = -1;
-          if (incoming == 4) chKickMode(sbyte),incoming = -1;
-          if (incoming == 5) chBowMode(sbyte),incoming = -1;
-          if (incoming == 6) bowOn=(sbyte),incoming = -1;
+          if (incoming == audioIncoming(AUDIO_CMD_OP_MODE)) chOpMode(sbyte),incoming = -1;
+          if (incoming == audioIncoming(AUDIO_CMD_DISP_MODE)) chDispMode(sbyte),incoming = -1;
+          if (incoming == audioIncoming(AUDIO_CMD_KICK_MODE)) chKickMode(sbyte),incoming = -1;
+          if (incoming == audioIncoming(AUDIO_CMD_BOW_MODE)) chBowMode(sbyte),incoming = -1;
+          if (incoming == audioIncoming(AUDIO_CMD_BOW_ON)) bowOn=(sbyte),incoming = -1;
 
-        if (incoming == 11){
+        if (incoming == audioIncoming(AUDIO_CMD_VOLUME)){
           float val=sbyte/199.0;
           val=val*val*2;
           ampOut.gain(val+0.0001);
@@ -147,7 +149,7 @@ void serialEvent1(){
           //Serial.println(val);
           incoming = -1;
         }
-        if (incoming == 17){
+        if (incoming == audioIncoming(AUDIO_CMD_BPM)){
           float val=sbyte;
           bpm=val;
           //Serial.println("bpm: ");

--- a/software/firmwareCtl/13_serialEvents.ino
+++ b/software/firmwareCtl/13_serialEvents.ino
@@ -1,8 +1,11 @@
+#include "ProtocolAudio.h"
+#include "ProtocolHid.h"
+
 void serialEvent1(){
   int incoming=-1;
   byte sbyte = Serial1.read();
-  if (sbyte > 199 && sbyte <= 255) incoming = sbyte - 200;
-    if (incoming == 6){
+  if (sbyte >= AUDIO_CMD_BASE && sbyte <= AUDIO_CMD_MAX) incoming = audioIncoming(sbyte);
+    if (incoming == audioIncoming(AUDIO_STATUS_STR_PITCH)){
     byte a;
     byte b;
     byte c;
@@ -14,7 +17,7 @@ void serialEvent1(){
     c=Serial1.read();
     strP[a]=b+c/100.0;
   }
-    if (incoming == 7){
+    if (incoming == audioIncoming(AUDIO_STATUS_STR_AMPLITUDE)){
     byte a;
     byte b;
     while(Serial1.available() == 0);
@@ -29,15 +32,15 @@ void serialEvent7(){
    
   int incoming=-1;
   byte serbyte = Serial7.read();
-  if (serbyte > 200 && serbyte < 255) incoming = serbyte - 201;
+  if (serbyte >= HID_CMD_BASE && serbyte <= HID_CMD_MAX) incoming = hidIncoming(serbyte);
   //if (serbyte == 255)sndGetMidi();
 
   if(incoming>=0){
     while(Serial7.available() == 0);
     byte val=Serial7.read();
-    if (incoming <19) rcvHidD(incoming,val),incoming=-1;
-    if (incoming >=19 && incoming < 38) rcvHidA(incoming-19,val);
-    if (incoming >=38 && incoming < 41) rcvHidR(incoming-38,val);
-    if (incoming >=41 && incoming < 49) rcvHidE(incoming-41,val-100);
+    if (incoming < HID_ANALOG_OFFSET) rcvHidD(incoming,val),incoming=-1;
+    if (incoming >= HID_ANALOG_OFFSET && incoming < HID_ROTARY_OFFSET) rcvHidA(incoming - HID_ANALOG_OFFSET,val);
+    if (incoming >= HID_ROTARY_OFFSET && incoming < HID_ENCODER_OFFSET) rcvHidR(incoming - HID_ROTARY_OFFSET,val);
+    if (incoming >= HID_ENCODER_OFFSET && incoming < HID_ENCODER_END_OFFSET) rcvHidE(incoming - HID_ENCODER_OFFSET,val - HID_ENCODER_CENTER);
   }
 }

--- a/software/firmwareCtl/2audio.ino
+++ b/software/firmwareCtl/2audio.ino
@@ -1,5 +1,7 @@
+#include "ProtocolAudio.h"
+
 void sndLfo1(byte para, float val){
-  Serial1.write(216);
+  Serial1.write(AUDIO_CMD_LFO_1);
   //delayMicroseconds(waitS);
   Serial1.write(para);
   //delayMicroseconds(waitS);
@@ -7,7 +9,7 @@ void sndLfo1(byte para, float val){
 }
 
 void sndStrGain(int str, byte val) {
-  Serial1.write(212);
+  Serial1.write(AUDIO_CMD_STR_GAIN);
   //delayMicroseconds(waitS);
   Serial1.write(str);
   //delayMicroseconds(waitS);
@@ -20,12 +22,12 @@ void sndStrGain(int str, byte val) {
 }
 
 void sndVol(float val){
-  Serial1.write(211);
+  Serial1.write(AUDIO_CMD_VOLUME);
   Serial1.write(byte(val*125)); //lowered to avoid clipping
 }
 
 void sndFilter(byte para, float val){
-  Serial1.write(209);
+  Serial1.write(AUDIO_CMD_FILTER);
   //delayMicroseconds(waitS);
   Serial1.write(para);
   //delayMicroseconds(waitS);
@@ -33,7 +35,7 @@ void sndFilter(byte para, float val){
 }
 
 void sndEnv2(byte para, float val){
-  Serial1.write(208);
+  Serial1.write(AUDIO_CMD_ENV_2);
   //delayMicroseconds(waitS);
   Serial1.write(para);
   //delayMicroseconds(waitS);
@@ -41,7 +43,7 @@ void sndEnv2(byte para, float val){
 }
 
 void sndEnv1(byte para, float val){
-  Serial1.write(207);
+  Serial1.write(AUDIO_CMD_ENV_1);
   //delayMicroseconds(waitS);
   Serial1.write(para);
   //delayMicroseconds(waitS);
@@ -49,18 +51,18 @@ void sndEnv1(byte para, float val){
 }
 
 void sndBowMode(byte mode){
-  Serial1.write(205);
+  Serial1.write(AUDIO_CMD_BOW_MODE);
   Serial1.write(mode);
 }
 
 void sndBowOn(byte mode){
-  Serial1.write(206);
+  Serial1.write(AUDIO_CMD_BOW_ON);
   Serial1.write(mode);
   //bowOn=mode;
 }
 
 void sndTrigEnv(byte str, float vel){
-  Serial1.write(200);
+  Serial1.write(AUDIO_CMD_TRIG_ENV);
   //delayMicroseconds(waitS);
   Serial1.write(str);
   //delayMicroseconds(waitS);
@@ -74,7 +76,7 @@ void sndTrigEnv(byte str, float vel){
 }
 
 void sndStrPrs(byte str, byte pitch, byte state){
-  Serial1.write(201);
+  Serial1.write(AUDIO_CMD_STR_FRET);
   //delayMicroseconds(waitS);
   Serial1.write(str);
   //delayMicroseconds(waitS);

--- a/software/firmwareCtl/ProtocolAudio.h
+++ b/software/firmwareCtl/ProtocolAudio.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <Arduino.h>
+
+constexpr byte AUDIO_CMD_BASE = 200;
+constexpr byte AUDIO_CMD_MAX = 255;
+
+// CTL -> Audio command bytes.
+constexpr byte AUDIO_CMD_TRIG_ENV = 200;
+constexpr byte AUDIO_CMD_STR_FRET = 201;
+constexpr byte AUDIO_CMD_OP_MODE = 202;
+constexpr byte AUDIO_CMD_DISP_MODE = 203;
+constexpr byte AUDIO_CMD_KICK_MODE = 204;
+constexpr byte AUDIO_CMD_BOW_MODE = 205;
+constexpr byte AUDIO_CMD_BOW_ON = 206;
+constexpr byte AUDIO_CMD_ENV_1 = 207;
+constexpr byte AUDIO_CMD_ENV_2 = 208;
+constexpr byte AUDIO_CMD_FILTER = 209;
+constexpr byte AUDIO_CMD_VOLUME = 211;
+constexpr byte AUDIO_CMD_STR_GAIN = 212;
+constexpr byte AUDIO_CMD_FX = 215;
+constexpr byte AUDIO_CMD_LFO_1 = 216;
+constexpr byte AUDIO_CMD_BPM = 217;
+constexpr byte AUDIO_CMD_MIDI_CC = 218;
+
+// Audio -> CTL status command bytes.
+constexpr byte AUDIO_STATUS_NOTE = 201;
+constexpr byte AUDIO_STATUS_CC = 205;
+constexpr byte AUDIO_STATUS_STR_PITCH = 206;
+constexpr byte AUDIO_STATUS_STR_AMPLITUDE = 207;
+
+constexpr byte audioIncoming(byte command) {
+  return command - AUDIO_CMD_BASE;
+}

--- a/software/firmwareCtl/ProtocolHid.h
+++ b/software/firmwareCtl/ProtocolHid.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <Arduino.h>
+
+constexpr byte HID_CMD_BASE = 201;
+constexpr byte HID_CMD_MAX = 254;
+constexpr byte HID_FRAME_END = 255;
+
+constexpr byte HID_DIGITAL_OFFSET = 0;
+constexpr byte HID_ANALOG_OFFSET = 19;
+constexpr byte HID_ROTARY_OFFSET = 38;
+constexpr byte HID_ENCODER_OFFSET = 41;
+constexpr byte HID_ENCODER_END_OFFSET = 49;
+constexpr byte HID_ENCODER_CENTER = 100;
+constexpr byte HID_ANALOG_MAX_VALUE = 200;
+
+constexpr byte hidIncoming(byte command) {
+  return command - HID_CMD_BASE;
+}

--- a/software/firmwareHid/ProtocolHid.h
+++ b/software/firmwareHid/ProtocolHid.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <Arduino.h>
+
+constexpr byte HID_CMD_BASE = 201;
+constexpr byte HID_CMD_MAX = 254;
+constexpr byte HID_FRAME_END = 255;
+
+constexpr byte HID_DIGITAL_OFFSET = 0;
+constexpr byte HID_ANALOG_OFFSET = 19;
+constexpr byte HID_ROTARY_OFFSET = 38;
+constexpr byte HID_ENCODER_OFFSET = 41;
+constexpr byte HID_ENCODER_END_OFFSET = 49;
+constexpr byte HID_ENCODER_CENTER = 100;
+constexpr byte HID_ANALOG_MAX_VALUE = 200;
+
+constexpr byte hidIncoming(byte command) {
+  return command - HID_CMD_BASE;
+}

--- a/software/firmwareHid/send.ino
+++ b/software/firmwareHid/send.ino
@@ -1,33 +1,35 @@
+#include "ProtocolHid.h"
+
 void sndA(byte idx, int val){
-  Serial6.write(idx + nDigital + 201);
+  Serial6.write(idx + nDigital + HID_CMD_BASE);
   delayMicroseconds(waitS);
-  Serial6.write(map(val, 0,1023,0,200));
+  Serial6.write(map(val, 0,1023,0,HID_ANALOG_MAX_VALUE));
   delayMicroseconds(waitS);
 }
 
 void sndD(byte idx, int val){
-  Serial6.write(idx + 201);
+  Serial6.write(idx + HID_CMD_BASE);
   delayMicroseconds(waitS);
   Serial6.write(val);
   delayMicroseconds(waitS);
 }
 
 void sndR(byte idx, int val){
-  Serial6.write(idx + nDigital + 19 + 201);
+  Serial6.write(idx + HID_ROTARY_OFFSET + HID_CMD_BASE);
   delayMicroseconds(waitS);
   Serial6.write(val);
   delayMicroseconds(waitS);
 }
 
 void sndE(byte idx, int val){
-  Serial6.write(idx + nDigital + 22 + 201);
+  Serial6.write(idx + HID_ENCODER_OFFSET + HID_CMD_BASE);
   delayMicroseconds(waitS);
   Serial6.write(val);
   delayMicroseconds(waitS);
 }
 
 void sndF(){
-  Serial6.write(255);
+  Serial6.write(HID_FRAME_END);
 }
 
 void sendAll(){


### PR DESCRIPTION
### Motivation
- Replace scattered numeric magic values with centralized protocol definitions to improve readability and maintainability across firmware components.
- Unify command/status encoding and decoding between audio, control (CTL), and HID firmware to prevent mismatches and simplify future changes.

### Description
- Add `ProtocolAudio.h` (in `firmwareAudio` and `firmwareCtl`) which defines `AUDIO_CMD_*`, `AUDIO_STATUS_*`, `AUDIO_CMD_BASE`, `AUDIO_CMD_MAX`, and the helper `audioIncoming` function.
- Add `ProtocolHid.h` (in `firmwareCtl` and `firmwareHid`) which defines `HID_CMD_BASE`, `HID_CMD_MAX`, `HID_FRAME_END`, offsets like `HID_ANALOG_OFFSET`/`HID_ROTARY_OFFSET`/`HID_ENCODER_OFFSET`, `HID_ENCODER_CENTER`, `HID_ANALOG_MAX_VALUE`, and the helper `hidIncoming` function.
- Update send/receive code to include the new headers and replace numeric literals with the new constants in `software/firmwareAudio/2ctl.ino`, `software/firmwareAudio/yLoop.ino`, `software/firmwareCtl/13_serialEvents.ino`, `software/firmwareCtl/2audio.ino`, and `software/firmwareHid/send.ino`.
- Adjust HID analog scaling and encoder value handling to use `HID_ANALOG_MAX_VALUE` and `HID_ENCODER_CENTER` instead of hardcoded numbers.

### Testing
- Compiled the `firmwareAudio` sketches successfully with the new headers and constant replacements.
- Compiled the `firmwareCtl` sketches successfully with updated serial handling and protocol definitions.
- Compiled the `firmwareHid` sketches successfully after replacing magic numbers with `ProtocolHid.h` constants.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3379655c3c83328d0ee93f550d7731)