### PR TITLE
docs: add board protocol reference tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,30 @@ Here is a list with the most important "guitar-extensions" I've implemented on t
     10 faders, 7 potis, 8 rotary encoder(&switches), 5 buttons, 7 toggle switches, 3 rotary switches (12steps), an analog joystick
     128*64 oled display
 
+## Documentation quick reference
+
+This repository contains three cooperating firmware targets. The tables below summarize the currently documented board roles, serial links, and hardware/protocol references without changing firmware behavior.
+
+### Board roles
+
+| Board firmware | Target noted in docs | Main role | Documentation |
+| --- | --- | --- | --- |
+| `software/firmwareHid` | Teensy 3.5 | Body controls, encoder/analog/digital input scanning, and local OLED rendering. | `docs/architecture.md`, `docs/protocols.md`, `docs/pinout.md` |
+| `software/firmwareCtl` | Teensy 4.1 | Main controller for system state, LED fretboard, fretboard sensing, Kickup, MulEBow control, sequencer/MIDI/SD coordination, and board-to-board routing. | `docs/architecture.md`, `docs/protocols.md`, `docs/realtime.md` |
+| `software/firmwareAudio` | Teensy 4.1 | Hexaphonic audio processing, pitch/amplitude analysis, per-string DSP, and actuator audio/control outputs. | `docs/architecture.md`, `docs/protocols.md`, `docs/realtime.md` |
+
+### Serial protocol map
+
+| Link | Baud | Purpose | Details |
+| --- | ---: | --- | --- |
+| HID <-> CTL | 115200 | Body-control events from HID to CTL and AsciiMassage display commands from CTL to HID. | `docs/protocols.md` |
+| CTL <-> Audio | 250000 | Raw byte audio-control commands from CTL to Audio and pitch/amplitude status from Audio to CTL. | `docs/protocols.md` |
+
+### Hardware and timing notes
+
+| Topic | Documentation file | Notes |
+| --- | --- | --- |
+| Pin assignments | `docs/pinout.md` | Documents firmware-inferred pins only; hardware connector names remain open unless present in source. |
+| Realtime intervals | `docs/realtime.md` | Documents LED, fretboard debounce, Kickup, display, clock, HID, and audio intervals. |
+| Testing guidance | `docs/testing.md` | Lists safe checks and hardware validation areas. |
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,6 +16,14 @@ ElektroCaster is a hardware/firmware electric guitar platform with:
 
 The firmware is split across three microcontrollers.
 
+## Board role summary
+
+| Firmware | Board role | Owns / directly touches | Communicates with | Protected behavior to preserve |
+| --- | --- | --- | --- | --- |
+| `software/firmwareHid` | Body-control and display companion | Analog controls, digital controls, encoders, resistor-ladder rotary switches, SH1106 128x64 OLED | `firmwareCtl` over `Serial6` at 115200 baud | HID command byte layout, display packet names/payloads, input pin assignments |
+| `software/firmwareCtl` | Main coordinator | LED fretboard, fretboard contact scanning, Kickup pins/timing, MIDI, SD song state, display composition, Audio/HID routing | `firmwareHid` over `Serial7` at 115200 baud; `firmwareAudio` over `Serial1` at 250000 baud; USB/hardware MIDI | Fretboard scan/debounce, Kickup pulse timing, serial payload formats, LED pin/mapping |
+| `software/firmwareAudio` | Hexaphonic DSP and actuator-audio board | TDM audio I/O, CS42448 codec control, per-string DSP, analysis objects, coil/MulEBow outputs | `firmwareCtl` over `Serial1` at 250000 baud | AudioConnection graph, audio routing, analysis intervals, audio command scaling |
+
 ## Microcontroller roles
 
 ### `software/firmwareHid`

--- a/docs/pinout.md
+++ b/docs/pinout.md
@@ -2,6 +2,14 @@
 
 This document records pin assignments inferable from firmware source. It does not change pin values. Hardware labels and board connector names are open unless explicitly shown in code.
 
+## Board-level pin ownership
+
+| Firmware | Pin / hardware area | Source of truth in firmware | Notes |
+| --- | --- | --- | --- |
+| `software/firmwareHid` | Body controls, encoders, OLED I2C | `software/firmwareHid/HardwareConfig.h`, `software/firmwareHid/firmwareHid.ino` | OLED constructor uses hardware I2C with `U8X8_PIN_NONE`; exact SDA/SCL board pins are implied by Teensy hardware I2C rather than listed here. |
+| `software/firmwareCtl` | LED data, fret contacts, string sense pins, Kickup outputs | `software/firmwareCtl/HardwareConfig.h`, `software/firmwareCtl/firmwareCtl.ino` | LED matrix order is encoded in `led_pixPos`; fret and string scan semantics are timing-sensitive. |
+| `software/firmwareAudio` | TDM audio channels and codec/audio objects | `software/firmwareAudio/firmwareAudio.ino`, `software/firmwareAudio/0Setup.ino` | Physical codec connector labels are not documented in source. |
+
 ## `software/firmwareHid`
 
 ### Encoders
@@ -17,7 +25,7 @@ This document records pin assignments inferable from firmware source. It does no
 | `enc6` | `29`, `28` |
 | `enc7` | `45`, `44` |
 
-Open: `nEnc` is declared as `7` while eight encoders are instantiated and sent.
+Note: `nEnc` is declared as `8`; eight encoders are instantiated and sent.
 
 ### Analog inputs
 

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -13,6 +13,15 @@ This document records currently observed serial protocols. It is based on reposi
 
 Open question: physical wiring and electrical directionality are not documented in the repository.
 
+## Protocol byte-space summary
+
+| Direction | Transport | Framing style | Command / packet namespace | Payload style | Receiver notes |
+| --- | --- | --- | --- | --- | --- |
+| HID -> CTL | Raw bytes on HID/CTL serial link | Command/index byte followed by value byte; HID also sends `255` after `sendAllNew()` | Command bytes are offset from HID indexes using `+ 201`; CTL subtracts `201` before dispatch | One value byte per recognized input event | CTL blocks while waiting for payload bytes; no checksum or versioning identified. |
+| CTL -> HID display | AsciiMassage on HID/CTL serial link | Named AsciiMassage packets | Text packet names such as `str`, `int`, `frm`, `buf` | Packet-specific byte/int/long/string fields | HID delegates parsing/framing to AsciiMassage and executes U8g2 drawing calls. |
+| CTL -> Audio | Raw bytes on CTL/Audio serial link | Command byte `200..255`, then command-specific payload | Shared audio command constants; Audio decodes `command - 200` | One or more bytes; most scaled values are intended to stay `<= 199` | Audio uses blocking waits for payload bytes; no checksum or length byte identified. |
+| Audio -> CTL | Raw bytes on CTL/Audio serial link | Status command byte, then status-specific payload | Audio status constants reuse some numeric IDs from the opposite direction | Pitch/amplitude/status bytes | CTL decodes by direction, so numeric reuse is only safe because links are directional at parser level. |
+
 ## HID -> CTL protocol
 
 Implemented in:

--- a/docs/realtime.md
+++ b/docs/realtime.md
@@ -2,6 +2,18 @@
 
 This document records timing values inferable from firmware source. It does not change timing behavior.
 
+## Timing summary
+
+| Firmware | Area | Interval / value | Why it matters |
+| --- | --- | --- | --- |
+| `software/firmwareCtl` | LED fretboard refresh | `fled_frameInt = 50 ms` | Visible LED update cadence. |
+| `software/firmwareCtl` | Fretboard press masking/debounce | `fretMaskT = 50 ms`, `strBncs = 500 samples`, `strBncsP = 5000 samples` | Touch detection behavior; hardware-sensitive. |
+| `software/firmwareCtl` | Kickup actuation | `kickDur[6] = 5 ms`, `kCueInt = 3 ms` | Solenoid pulse width and stagger interval. |
+| `software/firmwareCtl` | Display refresh | `disp_frameInt = 200 ms` | OLED command generation cadence from CTL. |
+| `software/firmwareCtl` | Internal clock basis | 24 PPQN; default `bpm = 90` | Sequencer/MIDI-clock-style timing. |
+| `software/firmwareHid` | Serial byte spacing / analog averaging | `waitS = 50 us`, `analogReadAveraging(200)` | HID serial pacing and analog stability. |
+| `software/firmwareAudio` | Control / analysis loop | `ctlInt = 10 ms`, `nFrqInt = 20 ms`, `peakInt = 20 ms` | DSP status and CTL feedback cadence. |
+
 ## `software/firmwareCtl`
 
 ### LED fretboard


### PR DESCRIPTION
### Motivation

- Provide a compact, cross-cutting documentation reference for board roles, serial links, pin mapping, protocol byte spaces, and realtime intervals without modifying firmware behavior.  
- Make it easier to review and reason about inter-board protocols and protected hardware timing before any code changes or refactors.

### Description

- Add a README quick-reference section summarizing board roles, serial links, and where to find hardware/timing docs in the repository.  
- Add a board-role summary table to `docs/architecture.md` documenting ownership, communication links, and protected behavior to preserve.  
- Add a protocol byte-space summary to `docs/protocols.md` describing HID↔CTL display, HID→CTL, CTL→Audio, and Audio→CTL framing/command ranges.  
- Add a board-level pin ownership note and correct the HID encoder note to `nEnc = 8` in `docs/pinout.md`, and add a realtime/timing summary table to `docs/realtime.md` documenting LED, fretboard debounce, Kickup, display, clock, HID, and audio intervals.

### Testing

- Ran `git diff --check` to validate whitespace and simple diff issues and it succeeded.  
- Affected files: `README.md`, `docs/architecture.md`, `docs/protocols.md`, `docs/pinout.md`, `docs/realtime.md`.  
- Checks not run: firmware builds and uploads for `software/firmwareHid`, `software/firmwareCtl`, and `software/firmwareAudio`, hardware integration tests, and any CI/tooling that would exercise runtime protocol handling or timing-sensitive behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a368f0a0c833283af10e21e40b99b)