### PR TITLE
Gate audio debug output

### DIFF
--- a/software/firmwareAudio/firmwareAudio.ino
+++ b/software/firmwareAudio/firmwareAudio.ino
@@ -15,6 +15,15 @@
 
 const byte nStrings=6;
 #include "HardwareConfig.h"
+
+#define DEBUG_AUDIO 0
+#if DEBUG_AUDIO
+#define DBG_AUDIO_PRINT(x) Serial.print(x)
+#define DBG_AUDIO_PRINTLN(x) Serial.println(x)
+#else
+#define DBG_AUDIO_PRINT(x)
+#define DBG_AUDIO_PRINTLN(x)
+#endif
 const int nCtlFrets=17; //how many led frets
 byte midiCh=15;
 
@@ -200,20 +209,20 @@ void chOpMode(byte data){
 
 void chKickMode(byte data){
   kickMode=data;
-  Serial.print("kickmode-t: ");
-  Serial.println(kickMode);
+  DBG_AUDIO_PRINT("kickmode-t: ");
+  DBG_AUDIO_PRINTLN(kickMode);
   }
 
 void chBowMode(byte data){
   bowMode=data;
-  Serial.print("bowmode: ");
-  Serial.println(bowMode);
+  DBG_AUDIO_PRINT("bowmode: ");
+  DBG_AUDIO_PRINTLN(bowMode);
   }
 
 void chDispMode(byte data){
   dispMode=data;
-  Serial.print("dispmode: ");
-  Serial.println(dispMode);
+  DBG_AUDIO_PRINT("dispmode: ");
+  DBG_AUDIO_PRINTLN(dispMode);
   }
 
 void trigEnv(byte str, float val){
@@ -237,12 +246,12 @@ void trigEnv(byte str, float val){
 void strFret(byte str, byte pitch, byte state){
   //if(pitch==0)coilAmp[str].gain(0);
   chLfo1(0, pitch,str);
-  Serial.print("Str: ");
-  Serial.print(str);
-  Serial.print(" pitch: ");
-  Serial.println(pitch);  
-  Serial.print(" state: ");
-  Serial.println(state);
+  DBG_AUDIO_PRINT("Str: ");
+  DBG_AUDIO_PRINT(str);
+  DBG_AUDIO_PRINT(" pitch: ");
+  DBG_AUDIO_PRINTLN(pitch);
+  DBG_AUDIO_PRINT(" state: ");
+  DBG_AUDIO_PRINTLN(state);
   if(state==0)coilOsc[str].amplitude(0);
   if(bowOn==1&&state>0){
     //coilAmp[str].gain(50);

--- a/software/firmwareAudio/yLoop.ino
+++ b/software/firmwareAudio/yLoop.ino
@@ -88,9 +88,9 @@ void serialEvent1(){
            b=Serial1.read();  
            val=b/100.0;      
            chngStrOutGain(a, val);
-            Serial.print(a);
-            Serial.print(": ");
-            Serial.println(val);
+            DBG_AUDIO_PRINT(a);
+            DBG_AUDIO_PRINT(": ");
+            DBG_AUDIO_PRINTLN(val);
            incoming = -1;
           }
 
@@ -238,22 +238,22 @@ if(bowOn!=lastBowOn){
     if(bowOn==0)coilOsc[str].amplitude(0);
   }
 
-  Serial.print("bowOn: ");
-  Serial.println(bowOn);
+  DBG_AUDIO_PRINT("bowOn: ");
+  DBG_AUDIO_PRINTLN(bowOn);
   lastBowOn=bowOn;
 }
    
-if(0) {
+if(DEBUG_AUDIO) {
   if(millis() - last_time >= 3000) {
-    Serial.print("Proc = ");
-    Serial.print(AudioProcessorUsage());
-    Serial.print(" (");    
-    Serial.print(AudioProcessorUsageMax());
-    Serial.print("),  Mem = ");
-    Serial.print(AudioMemoryUsage());
-    Serial.print(" (");    
-    Serial.print(AudioMemoryUsageMax());
-    Serial.println(")");
+    DBG_AUDIO_PRINT("Proc = ");
+    DBG_AUDIO_PRINT(AudioProcessorUsage());
+    DBG_AUDIO_PRINT(" (");
+    DBG_AUDIO_PRINT(AudioProcessorUsageMax());
+    DBG_AUDIO_PRINT("),  Mem = ");
+    DBG_AUDIO_PRINT(AudioMemoryUsage());
+    DBG_AUDIO_PRINT(" (");
+    DBG_AUDIO_PRINT(AudioMemoryUsageMax());
+    DBG_AUDIO_PRINTLN(")");
     last_time = millis();
   }
 }


### PR DESCRIPTION
### Motivation
- Reduce noisy Serial output from the Audio firmware while preserving the ability to enable debug prints when needed. 

### Description
- Added a `DEBUG_AUDIO` compile-time flag and two print macros `DBG_AUDIO_PRINT` / `DBG_AUDIO_PRINTLN` guarded by that flag in `software/firmwareAudio/firmwareAudio.ino`. 
- Replaced direct `Serial.print`/`Serial.println` calls in `software/firmwareAudio/firmwareAudio.ino` with the gated `DBG_AUDIO_PRINT` macros to keep behavior unchanged when `DEBUG_AUDIO == 0`. 
- Replaced selected `Serial.print`/`Serial.println` usages and gated runtime processor/memory diagnostics in `software/firmwareAudio/yLoop.ino` with the same debug macros and enabled the diagnostics only when `DEBUG_AUDIO` is set. 
- No protocol IDs, pin assignments, audio routing, timing, or functional logic were changed. 

### Testing
- Ran `git diff --check` which passed with whitespace fixes applied. 
- Verified repository status with `git status --short` showing the two modified files staged and committed. 
- Did not run firmware build or hardware tests because no local `arduino-cli`/`pio` build tool or target hardware was used. 

Affected files:
- `software/firmwareAudio/firmwareAudio.ino`
- `software/firmwareAudio/yLoop.ino`

Checks not run:
- Firmware compile (no local `arduino-cli` / PlatformIO available).
- Firmware upload to hardware and hardware integration tests (Audio control / Audio I/O / MulEBow actuator tests).
- Any end-to-end protocol/hardware validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a38b146cc8332840c4d0ad6cf231e)