### PR TITLE
Decouple display updates from clock path

### DIFF
--- a/software/firmwareCtl/02_clock.ino
+++ b/software/firmwareCtl/02_clock.ino
@@ -38,7 +38,6 @@ void updIntClock(){
       sndMidiClck(1);
       cmpClck(mClock);        
     }
-    updDisplay();
     intClockTimer+=intClockInt;
   }
 }

--- a/software/firmwareCtl/03_display.ino
+++ b/software/firmwareCtl/03_display.ino
@@ -1,5 +1,7 @@
 void updDisplay(){
   if (millis()-disp_frameTimer > disp_frameInt){
+    if (!displayClockSafe()) return;
+    unsigned long disp_startMicros = micros();
     disp_Clr();
     switch (opMode){
       case strSetup_opMode:
@@ -24,8 +26,19 @@ void updDisplay(){
         break;
     }
     disp_Buf();
+    disp_lastDurationMicros=micros()-disp_startMicros;
     disp_frameTimer=millis();
   }
+}
+
+bool displayClockSafe(){
+  if (extClk == 0 && clckOn == 1){
+    unsigned long elapsed = micros()-intClockTimer;
+    unsigned long needed = disp_lastDurationMicros+disp_clockGuardMicros;
+    if (elapsed >= intClockInt) return false;
+    if (intClockInt-elapsed <= needed) return false;
+  }
+  return true;
 }
 
 //display functions

--- a/software/firmwareCtl/06_midi.ino
+++ b/software/firmwareCtl/06_midi.ino
@@ -70,7 +70,6 @@ void midiClock(){
   if(extClk==1 && clckOn==1){
     mClock++;
     cmpClck(mClock);
-    updDisplay();
   }
 }
 

--- a/software/firmwareCtl/firmwareCtl.ino
+++ b/software/firmwareCtl/firmwareCtl.ino
@@ -269,6 +269,8 @@ const int chipSelect = BUILTIN_SDCARD;
 //display
   unsigned long disp_frameTimer; //timer for the led update
   unsigned int disp_frameInt=200;
+  unsigned long disp_lastDurationMicros=0; //measured display serialization time
+  const unsigned long disp_clockGuardMicros=1000; //keep this margin before the next internal clock tick
 
 // instance modes
   const int strSetup_opMode=0;
@@ -386,6 +388,7 @@ void setup() {
 void loop() {
   usbMIDI.read();    
   updIntClock();
+  updDisplay();
   if (fbrdMode == 1)readFretboard(0);
   if (fbrdMode == 0){
     if (frtb_sensMode==1)readFretboard(1);


### PR DESCRIPTION
### Motivation
- Prevent the display serialization from blocking or perturbing the internal clock by separating display refreshes from the clock tick path.
- Make display updates explicit in the main loop while preserving clock timing priority for musical accuracy.

### Description
- Removed the call to `updDisplay()` from `updIntClock()` so the internal clock path only advances clock state and schedules timing-sensitive work.
- Call `updDisplay()` explicitly from `loop()` immediately after `updIntClock()` to follow the suggested ordering `updIntClock(); updDisplay();`.
- Measure display serialization time in `disp_lastDurationMicros`, introduce `disp_clockGuardMicros`, and add `displayClockSafe()` to skip display refreshes when they would encroach on the next internal clock tick.
- Stop calling `updDisplay()` from the MIDI clock handler so external clock callbacks only update clock state.

### Testing
- Ran `git diff --check` and `git status --short` in this environment and both checks passed.
- No hardware or runtime timing tests were executed in this environment, so live timing impacts were not validated.
- Affected files: `software/firmwareCtl/02_clock.ino`, `software/firmwareCtl/03_display.ino`, `software/firmwareCtl/firmwareCtl.ino`, `software/firmwareCtl/06_midi.ino`.
- Checks not run: real Teensy timing/clock jitter measurements, live CTL→HID `Serial7` display serialization test, external MIDI-clock stability tests, and Kickup/fretboard hardware interaction tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b760120548332a28a573c71319a7c)