### PR TITLE
Fix firmwareCtl generic sequencer declarations and silence warnings

### DIFF
--- a/software/firmwareCtl/04_hid.ino
+++ b/software/firmwareCtl/04_hid.ino
@@ -47,8 +47,6 @@ void updateFretDebounce() {
 bool emitFretEvents(int *eventString, int *eventPress) {
   static long lastChng[nStrings];
   static int lastExStrPr[nStrings];
-  bool frtSplt=opMode>=genSq_opMode && opMode<genSq_opMode+genSq_nInst;
-
   for (int s = 0; s < nStrings; s++) {
     unsigned int sB = strBnc[s];
     unsigned int sBncs = strBncs;

--- a/software/firmwareCtl/10_op_genSq_Disp.ino
+++ b/software/firmwareCtl/10_op_genSq_Disp.ino
@@ -31,13 +31,12 @@ void genSq_drwGrid(){
     int nSteps=genSq_chn[inst][pttn][s][genSq_strEncFnc_stps];
     int off=genSq_chn[inst][pttn][s][genSq_strEncFnc_offSt]; //offset
     for(int f=0;f<genSq_maxVisSteps;f++){
-      int frt=f+off;
       for(int c=0;c<3;c++){  
         genSq_gridPix[s][f][c]=0;  
-        if(f%4==0 && f>=off && f<nSteps+off || f<off+nSteps-genSq_maxVisSteps){
+        if((f%4==0 && f>=off && f<nSteps+off) || f<off+nSteps-genSq_maxVisSteps){
           genSq_gridPix[s][f][c]=genSq_gridColor[inst][c]*5;
         }
-        if(f%4 != 0 && f>=off && f<nSteps+off || f<off+nSteps-genSq_maxVisSteps){
+        if((f%4 != 0 && f>=off && f<nSteps+off) || f<off+nSteps-genSq_maxVisSteps){
           genSq_gridPix[s][f][c]=genSq_gridColor[inst][c];
         }
       }
@@ -117,7 +116,7 @@ void genSq_drwStep(byte s){
     //int pitch=scls_scls[scls_sclSel][(genSq_stp[inst][pttn][s][f][genSq_strPrsFnc_sStp]+scls_sclStp)%scls_numSclStp[scls_sclSel]];
     for(int c=0;c<3;c++){
       genSq_stpPix[s][f][c]=0;    
-      if(genSq_stpOnOff[inst][pttn][s][f]>0 && f>=off && f<nSteps+off || f<off+nSteps-genSq_maxVisSteps){
+      if((genSq_stpOnOff[inst][pttn][s][f]>0 && f>=off && f<nSteps+off) || f<off+nSteps-genSq_maxVisSteps){
         if(chnl>0)genSq_stpPix[s][f][c]=tnClrs[pitch][c]*brght;
         if(chnl==0)genSq_stpPix[s][f][c]=brght/2;
       }

--- a/software/firmwareCtl/firmwareCtl.ino
+++ b/software/firmwareCtl/firmwareCtl.ino
@@ -174,7 +174,35 @@ const int chipSelect = BUILTIN_SDCARD;
   const int genSq_pttnMOff = nLedFrets-genSq_nPttn/2;
   int genSq_hrmInst=1;
   int genSq_strEncBtnSw = 1; //choose between button function or Encoder button select
-  
+
+
+  const int genSq_nTmDvs=14; //global
+  int genSq_tmDvs[genSq_nTmDvs]={384,192,96,64,48,32,24,16,12,8,6,4,3,2};
+  const char* genSq_tmDvNm[genSq_nTmDvs]={"4","2","1",".75","/2","/3","/4","/6","/8","/12","/16","/24","/32","/48"};
+
+  const char* genSq_strPrsNm[]={"pStp","oct","vel","c10","c11","c12"};
+  const int genSq_strPrsFnc_sStp=0;
+  const int genSq_strPrsFnc_oct=1;
+  const int genSq_strPrsFnc_vel=2;
+  const int genSq_strPrsFnc_cc1=3;
+  const int genSq_strPrsFnc_cc2=4;
+  const int genSq_strPrsFnc_cc3=5;
+  const int genSq_nStrPrsFnc=6;
+  const int genSq_SelChnCC=127; //selected channel; currently commented
+  const int genSq_maxStpV[genSq_nStrPrsFnc]={12,9,50,99,99,99};
+  int genSq_strPrsFnc=0;
+
+  const char* genSq_strEncNm[]={"tmDv","offSt","stps","sync","chn"};
+  const int genSq_strEncFnc_stps=2;
+  const int genSq_strEncFnc_tmDv=0;
+  const int genSq_strEncFnc_offSt=1;
+  const int genSq_strEncFnc_sync=3;
+  const int genSq_strEncFnc_chn=4;
+
+  const int genSq_nStrEncFnc=5;
+  const int genSeq_maxEncV[genSq_nStrPrsFnc]={genSq_nTmDvs,16,genSq_maxVisSteps,6,16};
+  int genSq_strEncFnc=0;
+  int genSq_strEncChAStps=0;
 
   const int genSq_nInst = 3;
   int genSq_actInst = 0;
@@ -249,34 +277,6 @@ const int chipSelect = BUILTIN_SDCARD;
   float genSq_pttnGridPix[nStrings][genSq_nPttn/2][3];
   float genSq_pttnPttnPix[nStrings][genSq_nPttn/2][3];
 
-  const int genSq_nTmDvs=14; //global
-  int genSq_tmDvs[genSq_nTmDvs]={384,192,96,64,48,32,24,16,12,8,6,4,3,2};
-  const char* genSq_tmDvNm[genSq_nTmDvs]={"4","2","1",".75","/2","/3","/4","/6","/8","/12","/16","/24","/32","/48"};
-
-  const char* genSq_strPrsNm[]={"pStp","oct","vel","c10","c11","c12"}; 
-  const int genSq_strPrsFnc_sStp=0;
-  const int genSq_strPrsFnc_oct=1;
-  const int genSq_strPrsFnc_vel=2;
-  const int genSq_strPrsFnc_cc1=3;
-  const int genSq_strPrsFnc_cc2=4;
-  const int genSq_strPrsFnc_cc3=5;
-  const int genSq_nStrPrsFnc=6;
-  const int genSq_SelChnCC=127; //selected channel; currently commented
-  const int genSq_maxStpV[genSq_nStrPrsFnc]={12,9,50,99,99,99};
-  int genSq_strPrsFnc=0;
-  
-  const char* genSq_strEncNm[]={"tmDv","offSt","stps","sync","chn"}; 
-  const int genSq_strEncFnc_stps=2;
-  const int genSq_strEncFnc_tmDv=0;
-  const int genSq_strEncFnc_offSt=1;
-  const int genSq_strEncFnc_sync=3;
-  const int genSq_strEncFnc_chn=4;
-  
-  const int genSq_nStrEncFnc=5;
-  const int genSeq_maxEncV[genSq_nStrPrsFnc]={genSq_nTmDvs,16,genSq_maxVisSteps,6,16};
-  int genSq_strEncFnc=0;
-  int genSq_strEncChAStps=0;
-  
   const char* genSq_strBtnNm[]={"mute", "rnd", "sclQ"};
   const int genSq_strBtnFnc_mute=0;
   const int genSq_strBtnFnc_rnd=1;


### PR DESCRIPTION
### Motivation
- Resolve compiler errors where sequencer array fields used constants that were not yet declared, causing undeclared identifier errors during build.
- Remove an unused local and silence `&&`/`||` precedence warnings to reduce clutter and avoid potential misinterpretation of intent.

### Description
- Move sequencer function-count and related `genSq_*` constants so `genSq_nStrPrsFnc` and `genSq_nStrEncFnc` are defined before `struct GenSeqPattern` in `software/firmwareCtl/firmwareCtl.ino`.
- Remove the unused local variable `frtSplt` from `emitFretEvents()` in `software/firmwareCtl/04_hid.ino` to eliminate an unused-variable warning.
- Add explicit parentheses to boolean expressions in `software/firmwareCtl/10_op_genSq_Disp.ino` to silence operator-precedence warnings while preserving existing logic.

### Testing
- Ran `git diff --check`, which passed after trimming trailing whitespace introduced during edits.
- Attempted to run a firmware build but `arduino-cli` was not available in the environment, so no compile was executed.
- No hardware tests were executed; runtime and hardware interactions (fretboard scan, LED fretboard, Kickup, MIDI/Serial, Audio board) remain unverified.
- Affected files: `software/firmwareCtl/firmwareCtl.ino`, `software/firmwareCtl/04_hid.ino`, `software/firmwareCtl/10_op_genSq_Disp.ino`; checks not run: firmware compilation via `arduino-cli` and all hardware validation tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b93a45e648332ba6b0fad06985033)