### PR TITLE
Add USB-Serial debug commands to firmwareCtl

### DIFF
--- a/software/firmwareCtl/15_debug.ino
+++ b/software/firmwareCtl/15_debug.ino
@@ -1,0 +1,157 @@
+namespace {
+const byte DEBUG_LINE_MAX = 48;
+char debugLine[DEBUG_LINE_MAX];
+byte debugLinePos = 0;
+
+bool debugTokenEquals(const char* value, const char* token){
+  while(*value != '\0' && *token != '\0'){
+    if(*value != *token)return false;
+    value++;
+    token++;
+  }
+  return *value == '\0' && *token == '\0';
+}
+
+bool debugTokenStartsWith(const char* value, const char* prefix){
+  while(*prefix != '\0'){
+    if(*value != *prefix)return false;
+    value++;
+    prefix++;
+  }
+  return true;
+}
+
+const char* songStatusName(SongStatus status){
+  switch(status){
+    case SONG_OK: return "OK";
+    case SONG_DEFAULT_USED_MISSING: return "DEFAULT_USED_MISSING";
+    case SONG_DEFAULT_USED_BAD_MAGIC: return "DEFAULT_USED_BAD_MAGIC";
+    case SONG_DEFAULT_USED_BAD_VERSION: return "DEFAULT_USED_BAD_VERSION";
+    case SONG_DEFAULT_USED_BAD_SIZE: return "DEFAULT_USED_BAD_SIZE";
+    case SONG_DEFAULT_USED_BAD_CRC: return "DEFAULT_USED_BAD_CRC";
+    case SONG_DEFAULT_USED_BAD_VALUE: return "DEFAULT_USED_BAD_VALUE";
+    case SONG_SAVE_FAILED: return "SAVE_FAILED";
+    case SONG_ERR_SLOT_RANGE: return "ERR_SLOT_RANGE";
+    default: return "UNKNOWN";
+  }
+}
+
+void debugPrintSongStatus(){
+  Serial.print("song slot=");
+  Serial.print(lastSongSlot);
+  Serial.print(" name=");
+  if(songValidSlot(lastSongSlot))Serial.print(genSq_SongNm[lastSongSlot]);
+  else Serial.print("<invalid>");
+  Serial.print(" status=");
+  Serial.println(songStatusName(lastSongStatus));
+}
+
+void debugPrintSongFile(int slot){
+  Serial.print("song ");
+  Serial.print(slot);
+  if(!songValidSlot(slot)){
+    Serial.println(" invalid-slot");
+    return;
+  }
+
+  char fileName[24];
+  songFileName(slot, fileName, sizeof(fileName));
+  Serial.print(" name=");
+  Serial.print(genSq_SongNm[slot]);
+  Serial.print(" file=");
+  Serial.print(fileName);
+  Serial.print(" exists=");
+  Serial.print(SD.exists(fileName) ? "yes" : "no");
+  Serial.print(" current=");
+  Serial.println(slot == genSq_actSng ? "yes" : "no");
+}
+
+void debugPrintSongs(){
+  for(int slot = 0; slot < genSq_nSngs; slot++){
+    debugPrintSongFile(slot);
+  }
+  debugPrintSongStatus();
+}
+
+void debugPrintStatus(){
+  Serial.println("ElektroCaster firmwareCtl debug");
+  Serial.print("millis=");
+  Serial.println(millis());
+  Serial.print("bpm=");
+  Serial.print(bpm);
+  Serial.print(" opMode=");
+  Serial.print(opMode);
+  Serial.print(" dispEncMode=");
+  Serial.print(dispEncMode);
+  Serial.print(" fbrdMode=");
+  Serial.println(fbrdMode);
+  Serial.print("clock running=");
+  Serial.print(clckOn ? "yes" : "no");
+  Serial.print(" external=");
+  Serial.println(extClk ? "yes" : "no");
+  debugPrintSongStatus();
+}
+
+void debugPrintHelp(){
+  Serial.println("USB debug commands:");
+  Serial.println("  help, ?       show this help");
+  Serial.println("  status        print runtime and last song status");
+  Serial.println("  song          print last song status");
+  Serial.println("  songs         list configured song slots and files");
+  Serial.println("  song <slot>   print one song slot, e.g. song 0");
+}
+
+void debugHandleLine(char* line){
+  while(*line == ' ' || *line == '\t')line++;
+  if(*line == '\0')return;
+
+  if(debugTokenEquals(line, "?") || debugTokenEquals(line, "help")){
+    debugPrintHelp();
+    return;
+  }
+  if(debugTokenEquals(line, "status")){
+    debugPrintStatus();
+    return;
+  }
+  if(debugTokenEquals(line, "song")){
+    debugPrintSongStatus();
+    return;
+  }
+  if(debugTokenEquals(line, "songs")){
+    debugPrintSongs();
+    return;
+  }
+  if(debugTokenStartsWith(line, "song ")){
+    int slot = atoi(line + 5);
+    debugPrintSongFile(slot);
+    return;
+  }
+
+  Serial.print("unknown debug command: ");
+  Serial.println(line);
+  debugPrintHelp();
+}
+}
+
+void debugSetup(){
+  Serial.println("USB debug ready. Type 'help' and press enter.");
+}
+
+void debugPoll(){
+  while(Serial.available() > 0){
+    char chr = (char)Serial.read();
+    if(chr == '\r')continue;
+    if(chr == '\n'){
+      debugLine[debugLinePos] = '\0';
+      debugHandleLine(debugLine);
+      debugLinePos = 0;
+      continue;
+    }
+    if(debugLinePos < DEBUG_LINE_MAX - 1){
+      debugLine[debugLinePos++] = chr;
+    }else{
+      debugLinePos = 0;
+      Serial.println("debug command too long");
+    }
+  }
+}

--- a/software/firmwareCtl/firmwareCtl.ino
+++ b/software/firmwareCtl/firmwareCtl.ino
@@ -372,6 +372,7 @@ void setup() {
     return;
   }
   Serial.println("initialization done.");
+  debugSetup();
 
   // init LEDs  
   LEDS.addLeds<WS2812SERIAL,LED_PIN,RGB>(frtPix,NUMPIXELS);
@@ -425,6 +426,7 @@ void setup() {
 }
 
 void loop() {
+  debugPoll();
   usbMIDI.read();    
   updIntClock();
   updDisplay();


### PR DESCRIPTION
### Motivation
- Provide a simple USB-Serial debug interface in `firmwareCtl` so runtime state and song load/save status can be inspected remotely. 
- The debug system must report song status details (including CRC/validation outcomes) without changing existing serial protocols, pin mappings, or realtime audio behavior.

### Description
- Add a new `software/firmwareCtl/15_debug.ino` implementing a line-buffered USB debug parser with commands `help`/`?`, `status`, `song`, `songs`, and `song <slot>` that print runtime and song-slot information to `Serial`.
- Add a `songStatusName()` helper to convert `SongStatus` enums to readable text and a set of printers for song file presence and last song status.
- Hook the debug system into the main firmware by calling `debugSetup()` after SD initialization and `debugPoll()` at the top of `loop()` in `software/firmwareCtl/firmwareCtl.ino` so no board-to-board serial links, baud rates, pins, or audio routing are modified.
- Keep the debug code in an internal namespace and use small, non-blocking polling on USB `Serial` to avoid altering timing-sensitive paths.

### Testing
- Automated checks run: `git diff --cached --check` and `git status` succeeded and the changes were committed; attempted `arduino-cli compile --fqbn teensy:avr:teensy41 software/firmwareCtl` failed because `arduino-cli` is not installed in the environment.
- Affected files: `software/firmwareCtl/15_debug.ino` (new) and `software/firmwareCtl/firmwareCtl.ino` (small edits to call `debugSetup()` and `debugPoll()`).
- Automated/hardware checks not run: firmware compile in this environment (toolchain unavailable) and all hardware integration tests, specifically `HID input test`, `Fretboard scan test`, `LED fretboard test`, `Kickup test`, `CTL-to-Audio / Audio-to-CTL live serial test`, `Audio I/O test`, and `MulEBow test`.
- Note: no protected behavior (pin assignments, serial protocol framing, audio `AudioConnection` routing, fretboard scanning debounce, Kickup timing) was changed by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4be51195e083328bfc574d59fb204a)