### PR TITLE
Save scale color setting with songs

### DIFF
--- a/software/firmwareCtl/14_song.ino
+++ b/software/firmwareCtl/14_song.ino
@@ -39,6 +39,7 @@ struct SongData {
   uint8_t rootNote;
   uint8_t sclSel;
   uint8_t sclStp;
+  uint8_t sclClr;
   uint8_t songBpm;
   uint8_t fledSrc;
   uint8_t songTuning[nStrings];
@@ -268,10 +269,11 @@ bool songValueFitsByte(int value){
 }
 
 bool songCollectFromRuntime(struct SongData* song){
-  if(!songValueFitsByte(rootNote) || !songValueFitsByte(scls_sclSel) || !songValueFitsByte(scls_sclStp) || !songValueFitsByte(bpm) || !songValueFitsByte(scls_fledSrc))return false;
+  if(!songValueFitsByte(rootNote) || !songValueFitsByte(scls_sclSel) || !songValueFitsByte(scls_sclStp) || !songValueFitsByte(scls_sclClr) || !songValueFitsByte(bpm) || !songValueFitsByte(scls_fledSrc))return false;
   song->rootNote = rootNote;
   song->sclSel = scls_sclSel;
   song->sclStp = scls_sclStp;
+  song->sclClr = scls_sclClr;
   song->songBpm = bpm;
   song->fledSrc = scls_fledSrc;
   for(int inst = 0; inst < genSq_nInst; inst++){
@@ -306,6 +308,7 @@ bool songValidateData(const struct SongData* song){
   if(song->rootNote > 11)return false;
   if(song->sclSel >= nScales)return false;
   if(song->sclStp >= scls_numSclStp[song->sclSel] && scls_numSclStp[song->sclSel] > 0)return false;
+  if(song->sclClr > 1)return false;
   if(song->songBpm < 1 || song->songBpm > 250)return false;
   for(int inst = 0; inst < genSq_nInst; inst++){
     for(int str = 0; str < nStrings; str++){
@@ -356,6 +359,7 @@ void songApply(const struct SongData* song){
   rootNote = song->rootNote;
   scls_sclSel = song->sclSel;
   scls_sclStp = song->sclStp;
+  scls_sclClr = song->sclClr;
   bpm = song->songBpm;
   chngBpm(bpm);
   scls_fledSrc = song->fledSrc;
@@ -393,6 +397,7 @@ void songBuildDefault(struct SongData* song){
   song->rootNote = 0;
   song->sclSel = 3;
   song->sclStp = 0;
+  song->sclClr = 1;
   song->songBpm = 90;
   song->fledSrc = 2;
   for(int str = 0; str < nStrings; str++){
@@ -412,6 +417,7 @@ bool songWriteMeta(File& file, const struct SongData* song, uint32_t* crc){
   if(!songWriteByte(file, song->rootNote, crc))return false;
   if(!songWriteByte(file, song->sclSel, crc))return false;
   if(!songWriteByte(file, song->sclStp, crc))return false;
+  if(!songWriteByte(file, song->sclClr, crc))return false;
   if(!songWriteByte(file, song->songBpm, crc))return false;
   if(!songWriteByte(file, song->fledSrc, crc))return false;
   return songFinishChunk(file, &chunk);
@@ -474,6 +480,11 @@ bool songReadMeta(File& file, struct SongData* song, uint32_t* crc){
   int value = songReadByte(file, crc); if(value < 0)return false; song->rootNote = value;
   value = songReadByte(file, crc); if(value < 0)return false; song->sclSel = value;
   value = songReadByte(file, crc); if(value < 0)return false; song->sclStp = value;
+  if(chunk.payloadLength >= 6){
+    value = songReadByte(file, crc); if(value < 0)return false; song->sclClr = value;
+  } else {
+    song->sclClr = 1;
+  }
   value = songReadByte(file, crc); if(value < 0)return false; song->songBpm = value;
   value = songReadByte(file, crc); if(value < 0)return false; song->fledSrc = value;
   return songSkipChunkRemaining(file, &chunk, crc);


### PR DESCRIPTION
### Motivation

- The scale color view flag `scls_sclClr` should be part of saved song state so that the UI color/white scale preference is preserved when loading songs.

### Description

- Add `sclClr` to `struct SongData` and copy runtime `scls_sclClr` into the captured song data in `songCollectFromRuntime`.
- Persist `sclClr` in the `META` chunk via `songWriteMeta` and restore it in `songReadMeta`, applying it to runtime in `songApply`.
- Make loading backward-compatible by defaulting missing `sclClr` to `1` when older META chunks are shorter, and validate the field with `songValidateData` (`sclClr` must be `0` or `1`).
- Initialize the default song with `sclClr = 1` in `songBuildDefault` so behavior is unchanged for new creations.

### Testing

- Ran `git diff --check` to verify there are no whitespace/merge diff problems and the repository change is staged and committed successfully.
- Affected file: `software/firmwareCtl/14_song.ino`.
- Not run: firmware compile/upload, because the local Arduino/Teensy toolchain is not available in this environment, and hardware song save/load validation on ElektroCaster hardware was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bfdf79d3883329ec63bd4012abfe5)