### PR TITLE
Fix display clock scheduling

### DIFF
--- a/software/firmwareCtl/03_display.ino
+++ b/software/firmwareCtl/03_display.ino
@@ -62,6 +62,7 @@ unsigned long disp_jobStartMicros = 0;
 unsigned long disp_jobSendMicros = 0;
 unsigned long disp_lastJobDurationMicros = 0;
 unsigned long disp_lastJobCommandCount = 0;
+unsigned long disp_lastCommandDurationMicros = 0;
 unsigned long disp_lastClockSlackMicros = 0;
 
 void updDisplay(){
@@ -134,13 +135,15 @@ void sendDisplayJobChunk(){
 
   byte sent = 0;
   while (disp_jobPos < disp_jobLen && sent < disp_maxCmdsPerChunk){
-    if (!displayClockSafeFor(disp_lastDurationMicros + disp_clockGuardMicros)) return;
+    if (!displayClockSafeFor(disp_lastCommandDurationMicros + disp_clockGuardMicros)) return;
     unsigned long slack = displayClockSlackMicros();
     if (slack > disp_lastClockSlackMicros) disp_lastClockSlackMicros = slack;
 
     unsigned long cmdStartMicros = micros();
     sendDisplayCmd(disp_jobPos);
-    disp_jobSendMicros += micros()-cmdStartMicros;
+    unsigned long cmdDurationMicros = micros()-cmdStartMicros;
+    disp_jobSendMicros += cmdDurationMicros;
+    if (cmdDurationMicros > disp_lastCommandDurationMicros) disp_lastCommandDurationMicros = cmdDurationMicros;
     disp_jobPos++;
     sent++;
   }
@@ -155,7 +158,7 @@ void sendDisplayJobChunk(){
 }
 
 bool displayClockSafe(){
-  return displayClockSafeFor(disp_lastDurationMicros+disp_clockGuardMicros);
+  return displayClockSafeFor(disp_lastCommandDurationMicros+disp_clockGuardMicros);
 }
 
 bool displayClockSafeFor(unsigned long needed){

--- a/software/firmwareCtl/15_debug.ino
+++ b/software/firmwareCtl/15_debug.ino
@@ -100,6 +100,8 @@ void debugPrintStatus(){
   Serial.print(disp_lastJobCommandCount);
   Serial.print(" sendMicros=");
   Serial.print(disp_lastDurationMicros);
+  Serial.print(" cmdMicros=");
+  Serial.print(disp_lastCommandDurationMicros);
   Serial.print(" jobMicros=");
   Serial.print(disp_lastJobDurationMicros);
   Serial.print(" maxClockSlackMicros=");


### PR DESCRIPTION
### Motivation
- Large display jobs (e.g. sequencer/fretboard mode) could be permanently blocked while the internal clock is running because the scheduler reserved the entire previous-frame send time before sending any chunk. 
- The OLED stopped responding when the clock was started in Sequencer mode but not in Scale mode, so scheduling must be more granular to allow small command chunks to make progress between clock ticks.

### Description
- Add a per-command timing measurement `disp_lastCommandDurationMicros` and update it for each `sendDisplayCmd` invocation in `sendDisplayJobChunk`.
- Use the per-command duration in the clock-safety checks (`displayClockSafeFor`) instead of the last full-frame send time so single commands can be scheduled while the internal clock is running.
- Expose the new metric via USB debug output by adding `cmdMicros` to `debugPrintStatus` for runtime diagnostics.

### Testing
- Ran repository checks (`git diff --check`) which reported no problems.
- Firmware build/upload and hardware validation (OLED + internal clock behavior in Sequencer vs Scale mode) were not executed in this environment and therefore runtime behavior on hardware remains unverified.
- Affected files: `software/firmwareCtl/03_display.ino`, `software/firmwareCtl/15_debug.ino`; checks not run: `firmware compile/upload`, `hardware OLED/clock tests`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cccc38e648332b734a5d24e07d4c1)