### PR TITLE
Update documentation to match current firmware protocol state

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@ Responsibilities:
 - Read body controls:
   - 22 analog inputs,
   - 19 digital inputs,
-  - 8 encoders are instantiated in code, although `nEnc` is currently `7`, which should be treated as an open inconsistency until verified on hardware,
+  - 8 encoders,
   - 3 analog resistor-ladder rotary switch values.
 - Send changed control values to `firmwareCtl` over a serial link.
 - Own the OLED display hardware through U8g2.
@@ -43,7 +43,8 @@ Responsibilities:
 
 Important files:
 
-- `software/firmwareHid/firmwareHid.ino`: pin arrays, encoder instances, input scanning loop, display initialization.
+- `software/firmwareHid/HardwareConfig.h`: HID input counts and pin arrays.
+- `software/firmwareHid/firmwareHid.ino`: encoder instances, input scanning loop, display initialization.
 - `software/firmwareHid/send.ino`: HID-to-CTL byte protocol.
 - `software/firmwareHid/receive.ino`: CTL-to-HID display command receiver.
 - `software/firmwareHid/display.ino`: local U8g2 drawing helpers.
@@ -68,6 +69,7 @@ Important files:
 
 - `software/firmwareCtl/firmwareCtl.ino`: large global state block, setup, main loop, hardware initialization.
 - `software/firmwareCtl/04_hid.ino`: fretboard scan/debounce plus HID processing and musical actions.
+- `software/firmwareCtl/ProtocolAudio.h` and `ProtocolHid.h`: shared byte constants for Audio and HID serial protocols.
 - `software/firmwareCtl/2audio.ino`: CTL-to-Audio command senders.
 - `software/firmwareCtl/13_serialEvents.ino`: serial receivers from Audio and HID.
 - `software/firmwareCtl/01_actuators.ino`: Kickup cueing and pulse handling.
@@ -91,6 +93,7 @@ Responsibilities:
 
 Important files:
 
+- `software/firmwareAudio/ProtocolAudio.h`: shared byte constants for the CTL/Audio serial protocol.
 - `software/firmwareAudio/firmwareAudio.ino`: global audio objects, state, static output summing connections.
 - `software/firmwareAudio/0Setup.ino`: audio hardware setup and per-string `AudioConnection` construction.
 - `software/firmwareAudio/yLoop.ino`: serial command parser, analysis loop, MulEBow state handling.
@@ -125,7 +128,7 @@ Additional flows:
 - Several files mix hardware access, state updates, UI handling, musical logic, and protocol handling.
 - Pin assignments and hardware mappings are embedded directly in firmware files.
 - Serial protocols use magic byte values and do not appear to have checksums, versioning, or documented recovery behavior.
-- Several serial parsers use blocking `while(Serial.available() == 0)` waits, which can hang if bytes are lost or boards reset mid-message.
+- Serial packet parsing is non-blocking on the inspected HID and Audio links and uses short packet timeouts, but the byte protocols still lack checksums, sequence numbers, explicit length bytes, or version negotiation.
 - `firmwareCtl/04_hid.ino` couples fretboard scanning, debounce, MIDI, Kickup, audio triggering, and sequencer editing.
 - `firmwareCtl/02_clock.ino` calls display updates from the internal clock path; timing impacts should be measured before changing it.
 - `firmwareAudio/0Setup.ino` builds many audio connections dynamically; audio routing changes are high risk.

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -17,19 +17,21 @@ Open question: physical wiring and electrical directionality are not documented 
 
 | Direction | Transport | Framing style | Command / packet namespace | Payload style | Receiver notes |
 | --- | --- | --- | --- | --- | --- |
-| HID -> CTL | Raw bytes on HID/CTL serial link | Command/index byte followed by value byte; HID also sends `255` after `sendAllNew()` | Command bytes are offset from HID indexes using `+ 201`; CTL subtracts `201` before dispatch | One value byte per recognized input event | CTL blocks while waiting for payload bytes; no checksum or versioning identified. |
+| HID -> CTL | Raw bytes on HID/CTL serial link | Command/index byte followed by value byte; HID also sends `255` after `sendAllNew()` | Command bytes are offset from HID indexes using `+ 201`; CTL subtracts `201` before dispatch | One value byte per recognized input event | CTL uses non-blocking packet assembly with a short timeout; no checksum or versioning identified. |
 | CTL -> HID display | AsciiMassage on HID/CTL serial link | Named AsciiMassage packets | Text packet names such as `str`, `int`, `frm`, `buf` | Packet-specific byte/int/long/string fields | HID delegates parsing/framing to AsciiMassage and executes U8g2 drawing calls. |
-| CTL -> Audio | Raw bytes on CTL/Audio serial link | Command byte `200..255`, then command-specific payload | Shared audio command constants; Audio decodes `command - 200` | One or more bytes; most scaled values are intended to stay `<= 199` | Audio uses blocking waits for payload bytes; no checksum or length byte identified. |
+| CTL -> Audio | Raw bytes on CTL/Audio serial link | Command byte `200..255`, then command-specific payload | Shared audio command constants; Audio decodes `command - 200` | One or more bytes; most scaled values are intended to stay `<= 199` | Audio uses non-blocking packet assembly with a short timeout; no checksum or length byte identified. |
 | Audio -> CTL | Raw bytes on CTL/Audio serial link | Status command byte, then status-specific payload | Audio status constants reuse some numeric IDs from the opposite direction | Pitch/amplitude/status bytes | CTL decodes by direction, so numeric reuse is only safe because links are directional at parser level. |
 
 ## HID -> CTL protocol
 
 Implemented in:
 
+- `software/firmwareHid/ProtocolHid.h`
 - `software/firmwareHid/send.ino`
+- `software/firmwareCtl/ProtocolHid.h`
 - `software/firmwareCtl/13_serialEvents.ino`
 
-General form: a command/index byte followed by one value byte. HID also emits `255` as a frame/end marker; CTL currently has a commented reference to it but no active handling was identified.
+General form: a command/index byte followed by one value byte. HID also emits `255` as a frame/end marker; CTL resets the current HID packet state when it receives this marker.
 
 Constants inferred from code:
 
@@ -43,13 +45,13 @@ Constants inferred from code:
 | Analog input | `idx + nDigital + 201` | `incoming >= 19 && incoming < 38` | 1 byte `val` | `analogRead` mapped from `0..1023` to `0..200`; indices `19..21` are excluded. |
 | Rotary switch | `idx + nDigital + 19 + 201` | `incoming >= 38 && incoming < 41` | 1 byte `val` | Rotary state index, likely `0..11`. |
 | Encoder delta | `idx + nDigital + 22 + 201` | `incoming >= 41 && incoming < 49` | 1 byte `val` | Delta encoded as `delta + 100`; CTL subtracts `100`. |
-| Frame/end marker | `255` | Not actively handled | none | Sent by HID after `sendAllNew()`. Semantics open. |
+| Frame/end marker | `255` | Packet-state reset marker | none | Sent by HID after `sendAllNew()`; CTL resets any pending HID packet state. |
 
 Open/incomplete:
 
-- There are 8 `Encoder` instances but `nEnc` is declared as `7`; protocol range supports 8 encoder indices `0..7` through decoded values `41..48`.
-- No checksum, timeout, or sequence number was identified.
-- CTL blocks waiting for value bytes after receiving a recognized command byte.
+- `nEnc` is declared as `8`; eight encoder instances are instantiated and the protocol range supports encoder indices `0..7` through decoded values `41..48`.
+- CTL uses a 20 ms timeout while assembling HID command/value pairs.
+- No checksum or sequence number was identified.
 
 ## CTL -> HID display protocol
 
@@ -89,7 +91,9 @@ Open/incomplete:
 
 Implemented in:
 
+- `software/firmwareCtl/ProtocolAudio.h`
 - `software/firmwareCtl/2audio.ino`
+- `software/firmwareAudio/ProtocolAudio.h`
 - `software/firmwareAudio/yLoop.ino`
 
 General form: first byte is a command ID in the range `200..255`. Audio computes `incoming = command - 200`. Payload length depends on command.
@@ -118,15 +122,17 @@ Known command IDs:
 Open/incomplete:
 
 - Commands `202`, `203`, `204`, `215`, `217`, and `218` are handled by Audio but corresponding CTL sender functions were not identified in `2audio.ino`.
-- Blocking reads are used for payload bytes.
-- No checksum, version, length byte, escaping, or resynchronization strategy was identified.
+- Audio uses a 10 ms timeout while assembling CTL-to-Audio packets.
+- No checksum, version, length byte, escaping, or full resynchronization strategy was identified beyond treating bytes `>= 200` as command/status bytes.
 - Values above `199` are treated as command bytes, so payload values should remain `<=199` unless explicitly safe.
 
 ## Audio -> CTL protocol
 
 Implemented in:
 
+- `software/firmwareAudio/ProtocolAudio.h`
 - `software/firmwareAudio/2ctl.ino`
+- `software/firmwareCtl/ProtocolAudio.h`
 - `software/firmwareCtl/13_serialEvents.ino`
 
 General form: first byte is a command ID, CTL computes `incoming = command - 200`.
@@ -135,12 +141,13 @@ Known command IDs:
 
 | Command byte | CTL `incoming` | Sender function | Payload | CTL receiver behavior |
 | --- | ---: | --- | --- | --- |
-| `201` | `1` | `sndNote(pitch, vel)` | `byte pitch`, `byte vel` | No active CTL receiver case was identified for `incoming == 1` in `13_serialEvents.ino`; source/receiver semantics open. |
-| `205` | `5` | `sndCC()` | `byte cc`, `byte val` | No active CTL receiver case was identified for `incoming == 5` in `13_serialEvents.ino`; source/receiver semantics open. |
+| `201` | `1` | `sndNote(pitch, vel)` | `byte pitch`, `byte vel` | Audio sender exists, but CTL currently assigns no payload length for this status, so these packets are ignored by the non-blocking parser. |
+| `205` | `5` | `sndCC()` | `byte cc`, `byte val` | Audio sender exists, but CTL currently assigns no payload length for this status, so these packets are ignored by the non-blocking parser. |
 | `206` | `6` | `sndStrP()` | `byte string`, `byte integerPart`, `byte fractionalPart` | CTL stores `strP[string] = integerPart + fractionalPart / 100.0`. |
 | `207` | `7` | `sndStrA()` | `byte string`, `byte amplitudePercent` | CTL stores `strA[string] = amplitudePercent / 100.0`. |
 
 Open/incomplete:
 
-- Audio sender functions for note/CC appear to exist, but CTL receiver handling was not identified in the inspected serial event file.
+- Audio sender functions for note/CC exist, but CTL currently ignores those status IDs because only pitch and amplitude are assigned receive payload lengths.
+- CTL uses a 10 ms timeout while assembling Audio-to-CTL status packets.
 - Same numeric command IDs are reused in opposite directions, which is acceptable on a bidirectional link only if direction is always clear.


### PR DESCRIPTION
### Motivation
- Bring repository documentation into agreement with the actual firmware sources for serial protocols and HID inputs. 
- Replace outdated claims about blocking serial reads and the `nEnc` inconsistency with the behaviour observed in the code. 
- Make the code-level protocol constants and packet-timeout behaviour discoverable by referencing shared header files.

### Description
- Update `docs/architecture.md` to record that HID instantiates eight encoders, surface `software/firmwareHid/HardwareConfig.h` as the source of HID counts/pin arrays, and note the shared `ProtocolAudio.h`/`ProtocolHid.h` headers used by CTL/Audio/HID. 
- Update `docs/protocols.md` to document that HID and Audio serial parsing is non-blocking with short timeouts, to document the HID frame-end (`255`) behaviour as a packet-state reset, and to note which Audio status IDs (note/CC) are currently ignored by CTL's receive-length table. 
- Small wording and provenance edits to point readers at `software/firmwareCtl/ProtocolAudio.h`, `software/firmwareHid/ProtocolHid.h`, and `software/firmwareAudio/ProtocolAudio.h` as authoritative constant sources. 

### Testing
- Ran `git diff --check` and created a commit; the check passed successfully. 
- This change is documentation-only and therefore no firmware build or hardware validation was performed. 
- Affected files: `docs/architecture.md`, `docs/protocols.md`. 
- Checks not run: firmware builds, hardware tests (HID/fretboard/LED/Kickup/Audio/MulEBow), and runtime protocol end-to-end validation on devices.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cea3498308332ad095f1fdea9fc9e)