### PR TITLE
Add string arpeggiator mode and integrate into HID, display and clock logic

### DIFF
--- a/software/firmwareCtl/04_hid.ino
+++ b/software/firmwareCtl/04_hid.ino
@@ -144,8 +144,8 @@ void procHidDChng(byte idx, bool val) {
 
     case 2:
       //tripple switch left
-      strArp_act = 0;
-      strSeq_act = val;
+      strSeq_act = val && !strArp_modeSel;
+      strArp_act = val && strArp_modeSel;
       break;
 
     case 3:
@@ -188,7 +188,8 @@ void procHidDChng(byte idx, bool val) {
       //if (val == 1)clck_strt();
       if (val == 1){
         genSq_actInst=(genSq_actInst+1)%genSq_nInst;
-        chOpMode(genSq_actInst+2);
+        if(genSq_actInst==0 && strArp_modeSel)chOpMode(strArp_opMode);
+        else chOpMode(genSq_actInst+genSq_opMode);
       }
       break;
 
@@ -368,10 +369,19 @@ void rcvHidR(byte idx, int val) {
   hidRVal[idx] = val;
   if (hidRVal[idx] != lastHidRVal[idx])procHidRChng(idx, val);
 }
+void updStrAutoMode(){
+  bool autoTrig = hidDVal[2];
+  strSeq_act = autoTrig && !strArp_modeSel;
+  strArp_act = autoTrig && strArp_modeSel;
+}
+
 void procHidRChng(byte idx, byte val) {
   switch (idx) {
     case 0:
       if(val<genSq_nPttn){
+        strArp_modeSel = 0;
+        updStrAutoMode();
+        if(opMode==strArp_opMode)chOpMode(genSq_opMode);
         if(shift==0){
           schdPttnCh[idx]=val;
           for (int i=0;i<genSq_nInst;i++){
@@ -383,11 +393,23 @@ void procHidRChng(byte idx, byte val) {
         }
         genSq_edtPttn[idx]=val;
       }
-      for (int i=0;i<genSq_nInst;i++){
-        if(val==11-i)genSq_syncInst[idx]=i;
-        if(val<=11-genSq_nInst)genSq_syncInst[idx]=-1;
+      if(val<=genSq_nPttn){
+        for (int i=0;i<genSq_nInst;i++){
+          if(val==11-i)genSq_syncInst[idx]=i;
+          if(val<=11-genSq_nInst)genSq_syncInst[idx]=-1;
+        }
       }
-      if(val==genSq_nPttn)chOpMode(0);
+      if(val>genSq_nPttn){
+        strArp_modeSel = 1;
+        strArp_modeVal = val;
+        updStrAutoMode();
+        if(opMode==genSq_opMode)chOpMode(strArp_opMode);
+      }
+      if(val==genSq_nPttn){
+        strArp_modeSel = 0;
+        updStrAutoMode();
+        chOpMode(0);
+      }
       break;
 
     case 1:

--- a/software/firmwareCtl/10_op_genSq_Disp.ino
+++ b/software/firmwareCtl/10_op_genSq_Disp.ino
@@ -170,13 +170,23 @@ void genSq_pttnDrwStat(){
   for(int i=0;i<genSq_nInst;i++){
     int actPttn=genSq_actPttn[i];
     int edtPttn=genSq_edtPttn[i];
-    int actStr=i*2+genSq_actPttn[i]/(genSq_nPttn/2);
-    int edtStr=i*2+genSq_edtPttn[i]/(genSq_nPttn/2);
+    if(i==0 && strArp_modeSel){
+      int arpPttn=11-strArp_modeVal;
+      if(arpPttn<0)arpPttn=0;
+      if(arpPttn>=genSq_nPttn)arpPttn=genSq_nPttn-1;
+      actPttn=arpPttn;
+      edtPttn=arpPttn;
+    }
+    int actStr=i*2+actPttn/(genSq_nPttn/2);
+    int edtStr=i*2+edtPttn/(genSq_nPttn/2);
     int actFrt=actPttn-genSq_nPttn/2*(actPttn/(genSq_nPttn/2));
     int edtFrt=edtPttn-genSq_nPttn/2*(edtPttn/(genSq_nPttn/2));
     for(int c=0;c<3;c++){  
-      genSq_pttnPttnPix[nStrings-1-edtStr][edtFrt][c]=0.07;
-      genSq_pttnPttnPix[nStrings-1-actStr][actFrt][c]=0.25;      
+      float edtVal=0.07;
+      float actVal=0.25;
+      if(i==0 && strArp_modeSel && c!=2)edtVal=0, actVal=0;
+      genSq_pttnPttnPix[nStrings-1-edtStr][edtFrt][c]=edtVal;
+      genSq_pttnPttnPix[nStrings-1-actStr][actFrt][c]=actVal;
     }
   }
 }

--- a/software/firmwareCtl/11_op_genSq_Do.ino
+++ b/software/firmwareCtl/11_op_genSq_Do.ino
@@ -15,24 +15,24 @@ void genSq_updClck(){
       }
     }
       for(int s=0;s<nStrings;s++){
-        if(genSq_nxtClkFil[inst][s] >= tmDv[inst][s]){
+        if(genSq_nxtClkFil[inst][s] >= tmDv[inst][s] && !(inst==0 && strArp_modeSel)){
           genSq_sndCC(inst,pttn, s);
         }
       }
       for(int s=0;s<nStrings;s++){
-        if(genSq_nxtClkFil[inst][s] >= tmDv[inst][s] - 1){
+        if(genSq_nxtClkFil[inst][s] >= tmDv[inst][s] - 1 && !(inst==0 && strArp_modeSel)){
           genSq_sndStpOff(inst,pttn, s);
         }
       }
       for(int s=0;s<nStrings;s++){
-        if(genSq_nxtClkFil[inst][s] >= tmDv[inst][s]){
+        if(genSq_nxtClkFil[inst][s] >= tmDv[inst][s] && !(inst==0 && strArp_modeSel)){
           if(genSq_muteCh[inst][s] == 0){
             genSq_sndStpOn(inst,pttn, s);
           }
         }
       }
       for(int s=0;s<nStrings;s++){
-        if(genSq_nxtClkFil[inst][s] >= tmDv[inst][s] - 1){
+        if(genSq_nxtClkFil[inst][s] >= tmDv[inst][s] - 1 && !(inst==0 && strArp_modeSel)){
           genSq_mstStr(inst,pttn,s);
         }
       }

--- a/software/firmwareCtl/firmwareCtl.ino
+++ b/software/firmwareCtl/firmwareCtl.ino
@@ -298,6 +298,8 @@ const int chipSelect = BUILTIN_SDCARD;
 
 // String Sequencer (from genSeq)
   bool strSeq_act=1;
+  bool strArp_modeSel=0;
+  byte strArp_modeVal=0;
 
 //sequence settings
   unsigned int bpm=90;


### PR DESCRIPTION
### Motivation
- Introduce a selectable string arpeggiator mode that is activated via the pattern selector and integrated with existing HID controls and operation modes. 
- Ensure the arpeggiator instance uses its own pattern value and visual representation while suppressing normal pattern clock/output for that instance. 

### Description
- Added `strArp_modeSel` and `strArp_modeVal` state and new helper `updStrAutoMode()` to map the HID auto-trigger input (`hidDVal[2]`) into `strSeq_act`/`strArp_act` based on arpeggiator selection. 
- Updated HID handlers so the rotary/pattern selector values > `genSq_nPttn` enable arpeggiator mode, set `strArp_modeVal`, and switch `opMode` to the arpeggiator mode when appropriate, and changed button behavior to route instance mode selection when arpeggiator is active. 
- Modified display rendering in `genSq_pttnDrwStat()` to use the arpeggiator pattern for instance 0 when `strArp_modeSel` is set and to adjust per-channel color output accordingly. 
- Updated clock/step logic in `genSq_updClck()` to suppress CC, step on/off and master/step behavior for `inst == 0` while arpeggiator mode is active so the arpeggiator can manage those events separately. 

### Testing
- Performed an automated firmware build of the project for the target (firmware compilation), and the build completed successfully. 
- No additional automated unit tests were present or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e262c4cd883328f5665e823d3eebd)