### PR TITLE
Show GenSeq pattern overlay in String Arp mode

### DIFF
--- a/software/firmwareCtl/05_ledfrets.ino
+++ b/software/firmwareCtl/05_ledfrets.ino
@@ -9,6 +9,7 @@ void updLedFrets(){
       case strArp_opMode:
         if(fbrdMode==0&&fbrdSeqVHld==0)scls_updFleds();
         if(fbrdMode==1||fbrdSeqVHld==1)strArp_updFleds();
+        genSq_updPttnFleds();
         break;
       case genSq_opMode:
         if(fbrdMode==0&&fbrdSeqVHld==0)scls_updFleds();


### PR DESCRIPTION
### Motivation
- The GenSeq pattern overlay was not visible when `strArp` was active and instance 0 was selected, so pattern status should be shown together with the String Arp LED update.

### Description
- Call `genSq_updPttnFleds()` from the `strArp_opMode` branch inside `updLedFrets()` so GenSeq pattern LEDs are drawn while String Arp is active, implemented in `software/firmwareCtl/05_ledfrets.ino`.

### Testing
- Ran `git diff --check` (no issues), committed the change with `git commit`, and verified `git status --short`; `arduino-cli` was not available so no firmware build was performed, and hardware LED tests were not run; affected file: `software/firmwareCtl/05_ledfrets.ino`, checks not run: firmware build (`arduino-cli`/toolchain) and on-device LED/hardware verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f8f133e44833281e8b8cad70a61ef)