### PR TITLE
Prevent display scheduler lockup during internal clock

### DIFF
--- a/software/firmwareCtl/03_display.ino
+++ b/software/firmwareCtl/03_display.ino
@@ -31,6 +31,7 @@ bool displayStateChanged();
 void cancelDisplayJob();
 void buildDisplayJob();
 void sendDisplayJobChunk();
+unsigned long displayCommandBudgetMicros();
 bool displayClockSafeFor(unsigned long needed);
 unsigned long displayClockSlackMicros();
 void queueDisplayCmd(byte kind, int a, int b, int c, int d, int e, long l, const char* str);
@@ -137,7 +138,7 @@ void sendDisplayJobChunk(){
 
   byte sent = 0;
   while (disp_jobPos < disp_jobLen && sent < disp_maxCmdsPerChunk){
-    if (!displayClockSafeFor(disp_lastCommandDurationMicros + disp_clockGuardMicros)) return;
+    if (!displayClockSafeFor(displayCommandBudgetMicros() + disp_clockGuardMicros)) return;
     unsigned long slack = displayClockSlackMicros();
     if (slack > disp_lastClockSlackMicros) disp_lastClockSlackMicros = slack;
 
@@ -145,7 +146,7 @@ void sendDisplayJobChunk(){
     sendDisplayCmd(disp_jobPos);
     unsigned long cmdDurationMicros = micros()-cmdStartMicros;
     disp_jobSendMicros += cmdDurationMicros;
-    if (cmdDurationMicros > disp_lastCommandDurationMicros) disp_lastCommandDurationMicros = cmdDurationMicros;
+    disp_lastCommandDurationMicros = cmdDurationMicros;
     disp_jobPos++;
     sent++;
   }
@@ -160,7 +161,14 @@ void sendDisplayJobChunk(){
 }
 
 bool displayClockSafe(){
-  return displayClockSafeFor(disp_lastCommandDurationMicros+disp_clockGuardMicros);
+  return displayClockSafeFor(displayCommandBudgetMicros()+disp_clockGuardMicros);
+}
+
+unsigned long displayCommandBudgetMicros(){
+  if (extClk == 0 && clckOn == 1 && disp_lastCommandDurationMicros + disp_clockGuardMicros >= intClockInt){
+    return 0;
+  }
+  return disp_lastCommandDurationMicros;
 }
 
 bool displayClockSafeFor(unsigned long needed){


### PR DESCRIPTION
### Motivation

- The display scheduler could permanently refuse to send further OLED commands when the internal clock was running after one long `Serial7` display write, because a sticky maximum command-duration value made the clock-safety check always fail.
- The intent is to keep display updates safe with respect to the internal clock while allowing the scheduler to recover after transient long serial writes.

### Description

- Replace the sticky maximum duration policy with an adaptive per-command duration by updating `disp_lastCommandDurationMicros` to the most recent command duration instead of keeping a persistent maximum.
- Introduce `displayCommandBudgetMicros()` and use it in the pre-send check so the scheduler falls back to a guard-only budget when the stored duration cannot fit in one clock tick.
- Use the new budget in `sendDisplayJobChunk()` and `displayClockSafe()` so display chunks are no longer permanently blocked by a single outlier command.
- Only `software/firmwareCtl/03_display.ino` was modified and no serial protocol, pin assignments, or realtime timing constants were changed.

### Testing

- Ran `git diff --check` which produced no whitespace/patch errors.
- The following affected file was changed: `software/firmwareCtl/03_display.ino`.
- The following checks were not run in this environment: firmware build using `arduino-cli`, unit tests, and any hardware-in-the-loop tests with a Teensy and OLED display; these should be run on-device to validate timing under an active clock.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55213555ac8332a08be1214cb69d9a)