### PR TITLE
Fix stuck strArp serial MIDI notes

### DIFF
--- a/software/firmwareCtl/06_midi.ino
+++ b/software/firmwareCtl/06_midi.ino
@@ -39,7 +39,7 @@ void sndMidiNotePress(int str, int frt, int chn){
     sndMidiNote(note,127, chn);
   }    
   if (frt == 0){ 
-    sndMidiNote(lastNote[str],0, lastChn[str]);
+    if (lastNote[str]!=0) sndMidiNote(lastNote[str],0, lastChn[str]);
     lastNote[str]=0;
   }
 }

--- a/software/firmwareCtl/09_op02_StrArp.ino
+++ b/software/firmwareCtl/09_op02_StrArp.ino
@@ -150,7 +150,20 @@ void strArp_updClckParallel(){
   }
 }
 
+void strArp_silenceInactiveSerialNotes(){
+  if(frtb_sensMode!=0)return;
+
+  for(int i = 0; i<nStrings; i++){
+    if(strPrs[i] == 0 || strArp_muteCh[i] == 1 || mtOut != 0 || strPrs[i] > nFrets-genSq_nPttn/2-1){
+      int chnl = genSq_chn[0][0][i][genSq_strEncFnc_chn];
+      sndMidiNotePress(i,0,chnl);
+    }
+  }
+}
+
 void strArp_updClckSerial(){
+  strArp_silenceInactiveSerialNotes();
+
   if(strArp_seqLen == 0){
     for(int s = 0; s<nStrings; s++){
       strArp_clk[s]=-1;


### PR DESCRIPTION
### Motivation
- Prevent stuck MIDI notes when `strArp` is used in serial mode by ensuring strings that are released, muted, globally muted, or moved out of range do not keep previously-sent notes ON.

### Description
- Add `strArp_silenceInactiveSerialNotes()` and call it at the start of `strArp_updClckSerial()` so inactive strings are explicitly silenced before the serial arpeggio clock advances.  
- Change `sndMidiNotePress()` to only send a Note-Off when a tracked `lastNote[str]` is non-zero to avoid redundant/invalid note-off messages.  
- Modified files: `software/firmwareCtl/09_op02_StrArp.ino`, `software/firmwareCtl/06_midi.ino`.

### Testing
- Ran `git diff --check` which found no whitespace or diff-check issues and completed successfully.  
- Checks not run: `arduino-cli`/Teensy compile and upload were not executed, MIDI serial strArp hardware regression tests were not performed, and fretboard scan / Kickup / actuator hardware tests were not run because physical hardware and a toolchain build were not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a574ee31a1083329d68cc5d8c21602b)