### PR TITLE
Fix stuck strArp serial MIDI notes

### DIFF
--- a/software/firmwareCtl/09_op02_StrArp.ino
+++ b/software/firmwareCtl/09_op02_StrArp.ino
@@ -187,6 +187,14 @@ void strArp_updClckSerial(){
   
   if(strArp_serialNxtClkFil >= strArp_tmDv[s]){
     strArp_serialNxtClkFil=0;
+    if(frtb_sensMode==0){
+      for(int i = 0; i<nStrings; i++){
+        if(i != s){
+          int offChnl = genSq_chn[0][0][i][genSq_strEncFnc_chn];
+          sndMidiNotePress(i,0,offChnl);
+        }
+      }
+    }
     if(frtb_sensMode==0 && strPrs[s]==0)sndMidiNotePress(s,0,chnl);
     if(strPrs[s] > 0 && strArp_muteCh[s]==0 && mtOut==0 && strPrs[s]<=nFrets-genSq_nPttn/2-1){
       if(frtb_sensMode==0)sndMidiNotePress(s,strPrs[s],chnl);


### PR DESCRIPTION
### Motivation
- Prevent serial string arpeggio from leaving the previously played string's MIDI note held when advancing to the next serial step by ensuring non-current strings receive note-off before the new note-on.

### Description
- In `strArp_updClckSerial()` added a loop that sends note-off via `sndMidiNotePress(i,0,offChnl)` for all strings `i != s` (non-current) before triggering the current string, in `software/firmwareCtl/09_op02_StrArp.ino`.

### Testing
- Ran `git diff --check` and `git status --short` which succeeded, and committed the change; no firmware build was performed because `arduino-cli` and `pio` are not available in this environment; affected file: `software/firmwareCtl/09_op02_StrArp.ino`; checks not run: firmware compile/upload and hardware MIDI/strArp validation (requires ElektroCaster hardware).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5752f858548332a0b57637951c198e)