### PR TITLE
Fix strArp serial cursor alignment

### DIFF
--- a/software/firmwareCtl/09_op02_StrArp.ino
+++ b/software/firmwareCtl/09_op02_StrArp.ino
@@ -162,6 +162,8 @@ void strArp_silenceInactiveSerialNotes(){
 }
 
 void strArp_updClckSerial(){
+  static int strArp_serialDisplayStep = -1;
+
   strArp_silenceInactiveSerialNotes();
 
   if(strArp_seqLen == 0){
@@ -169,11 +171,13 @@ void strArp_updClckSerial(){
       strArp_clk[s]=-1;
     }
     strArp_serialStep=0;
+    strArp_serialDisplayStep=-1;
     strArp_serialNxtClkFil=0;
     return;
   }
 
   if(strArp_serialStep >= strArp_seqLen)strArp_serialStep=0;
+  if(strArp_serialDisplayStep >= strArp_seqLen)strArp_serialDisplayStep=-1;
   byte s = strArp_seq[strArp_serialStep];
   int chnl = genSq_chn[0][0][s][genSq_strEncFnc_chn]; //midi channel is derived from first pattern of the firs instance of the genSeq
 
@@ -201,6 +205,7 @@ void strArp_updClckSerial(){
       sndTrigEnv(s, 1);
       kick(s);
     }
+    strArp_serialDisplayStep=strArp_serialStep;
     strArp_serialStep++;
     if(strArp_serialStep>=strArp_seqLen)strArp_serialStep=0;
   }
@@ -208,8 +213,10 @@ void strArp_updClckSerial(){
   for(int i = 0; i<nStrings; i++){
     strArp_clk[i]=-1;
   }
-  byte cursorString = strArp_seq[strArp_serialStep];
-  strArp_clk[cursorString]=strArp_serialStep;
+  if(strArp_serialDisplayStep >= 0){
+    byte cursorString = strArp_seq[strArp_serialDisplayStep];
+    strArp_clk[cursorString]=strArp_serialDisplayStep;
+  }
 }
 
 void strArp_sync(){


### PR DESCRIPTION
### Motivation
- The serial-mode string arpeggiator displayed the cursor on the next queued step instead of the step that just fired because `strArp_serialStep` was advanced before the cursor update, causing a one-step visual offset. 

### Description
- Add a persistent `static int strArp_serialDisplayStep` to record the fired serial step and use it for cursor/`strArp_clk` updates. 
- Set `strArp_serialDisplayStep` at the moment a step is fired and only then advance `strArp_serialStep`, and reset the display step when the arp sequence is empty or shrinks. 
- Use the saved `strArp_serialDisplayStep` when populating `strArp_clk` so the visible cursor matches the actual played step. 
- Affected file: `software/firmwareCtl/09_op02_StrArp.ino`. 

### Testing
- Ran `git diff --check` which reported no whitespace/format errors and the change was committed. 
- Affected files: `software/firmwareCtl/09_op02_StrArp.ino`. 
- Checks not run: firmware compilation/upload, hardware validation with the CTL board and LED fretboard, and end-to-end integration tests involving MIDI, Kickup, and audio; these must be run on hardware to confirm runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57568d4d748332993fe227958e3065)