### PR TITLE
Reset strArp serial cursor on sync

### DIFF
--- a/software/firmwareCtl/09_op02_StrArp.ino
+++ b/software/firmwareCtl/09_op02_StrArp.ino
@@ -162,8 +162,6 @@ void strArp_silenceInactiveSerialNotes(){
 }
 
 void strArp_updClckSerial(){
-  static int strArp_serialDisplayStep = -1;
-
   strArp_silenceInactiveSerialNotes();
 
   if(strArp_seqLen == 0){
@@ -225,6 +223,7 @@ void strArp_sync(){
       strArp_clk[s]=0;
   }
   strArp_serialStep=0;
+  strArp_serialDisplayStep=-1;
   strArp_serialNxtClkFil=0;
   if(strArp_seqLen > 0)strArp_serialNxtClkFil=strArp_tmDv[strArp_seq[0]];
 }

--- a/software/firmwareCtl/firmwareCtl.ino
+++ b/software/firmwareCtl/firmwareCtl.ino
@@ -144,6 +144,7 @@ const int chipSelect = BUILTIN_SDCARD;
   byte strArp_seq[strArp_maxSteps];
   byte strArp_seqLen=0;
   byte strArp_serialStep=0;
+  int strArp_serialDisplayStep=-1;
   byte strArp_serialNxtClkFil=0;
   byte strArp_tmDv[nStrings]={6,6,6,6,6,6};
   byte strArp_tmDvs[12]={96,64,48,32,24,16,12,8,6,4,3,2};


### PR DESCRIPTION
### Motivation
- Prevent the serial arpeggiator visual cursor from showing a stale/incorrect position after sequence sync by making its display state globally accessible and explicitly resetting it on sync.

### Description
- Promote the `strArp_serialDisplayStep` state from a function-local `static` to a shared `int` in `firmwareCtl.ino` and update `strArp_updClckSerial()` to read/clear the shared cursor variable and avoid writing a stale cursor when the sequence is empty or out-of-range, and reset the cursor inside `strArp_sync()`.

### Testing
- Ran `git diff --check` which completed without issues.
- Affected files: `software/firmwareCtl/firmwareCtl.ino`, `software/firmwareCtl/09_op02_StrArp.ino`.
- Checks not run: Arduino/Teensy firmware build, on-target hardware runtime tests (LED fretboard, serial/Audio integration, Kickup), and the full CI/toolchain compile because the Teensy build environment and physical hardware are unavailable here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5759f08b948332b898fd2212e5bec7)