### PR TITLE
Centralize strArp serial cursor reset

### DIFF
--- a/software/firmwareCtl/09_op02_StrArp.ino
+++ b/software/firmwareCtl/09_op02_StrArp.ino
@@ -161,6 +161,13 @@ void strArp_silenceInactiveSerialNotes(){
   }
 }
 
+void strArp_resetSerialCursor(){
+  strArp_serialStep=0;
+  strArp_serialDisplayStep=-1;
+  strArp_serialNxtClkFil=0;
+  if(strArp_seqLen > 0)strArp_serialNxtClkFil=strArp_tmDv[strArp_seq[0]];
+}
+
 void strArp_updClckSerial(){
   strArp_silenceInactiveSerialNotes();
 
@@ -168,9 +175,7 @@ void strArp_updClckSerial(){
     for(int s = 0; s<nStrings; s++){
       strArp_clk[s]=-1;
     }
-    strArp_serialStep=0;
-    strArp_serialDisplayStep=-1;
-    strArp_serialNxtClkFil=0;
+    strArp_resetSerialCursor();
     return;
   }
 
@@ -222,10 +227,7 @@ void strArp_sync(){
       strArp_nxtClkFil[s]=strArp_tmDv[s];
       strArp_clk[s]=0;
   }
-  strArp_serialStep=0;
-  strArp_serialDisplayStep=-1;
-  strArp_serialNxtClkFil=0;
-  if(strArp_seqLen > 0)strArp_serialNxtClkFil=strArp_tmDv[strArp_seq[0]];
+  strArp_resetSerialCursor();
 }
 
 void strArp_drwGrid(){


### PR DESCRIPTION
### Motivation
- Centralize and align resetting of the string-arpeggiator serial cursor so the empty-sequence and sync code paths behave identically.

### Description
- Add helper `strArp_resetSerialCursor()` that resets `strArp_serialStep`, `strArp_serialDisplayStep`, and `strArp_serialNxtClkFil` (and preloads the first-step timing when a sequence exists), and use it from `strArp_updClckSerial()` and `strArp_sync()` to remove duplicated reset logic.

### Testing
- Ran `git diff --check` and basic repo checks and committed the change; no build/runtime tests were executed in this environment; affected file: `software/firmwareCtl/09_op02_StrArp.ino`; checks not run: firmware compile/upload and hardware timing/behavior validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a575f3241348332a771995e52e4d47f)