### PR TITLE
Refactor string encoder mappings

### DIFF
--- a/software/firmwareCtl/09_op02_StrArp.ino
+++ b/software/firmwareCtl/09_op02_StrArp.ino
@@ -27,11 +27,11 @@ void strArp_chDispEnc(int val){
 
 void strArp_chStrEnc(byte s, int val){
   switch(strArp_strEncFnc){
-    case 0:
+    case strArp_strEncFnc_stps:
       if(strArp_nRpt[s] + val < 1) strArp_nRpt[s]=1;
       strArp_nRpt[s] = strArp_nRpt[s] + val;
       break;
-    case 1:
+    case strArp_strEncFnc_tmDv:
       if(strArp_tmDvSel[s] + val < 0) strArp_tmDvSel[s]=strArp_nTmDvs;
       strArp_tmDvSel[s] = (strArp_tmDvSel[s] + val)%strArp_nTmDvs;
       strArp_tmDv[s]=strArp_tmDvs[strArp_tmDvSel[s]];
@@ -79,8 +79,8 @@ void strArp_updDisp(){
 
   disp_Color(1);
   for(int s =0; s < nStrings;s++){
-    if(strArp_strEncFnc==0)disp_Int(108-s*21, 55, strArp_nRpt[s]);
-    if(strArp_strEncFnc==1)disp_Str(108-s*21, 55, strArp_tmDvNm[strArp_tmDvSel[s]]);
+    if(strArp_strEncFnc==strArp_strEncFnc_stps)disp_Int(108-s*21, 55, strArp_nRpt[s]);
+    if(strArp_strEncFnc==strArp_strEncFnc_tmDv)disp_Str(108-s*21, 55, strArp_tmDvNm[strArp_tmDvSel[s]]);
   }
 
   disp_Color(1);

--- a/software/firmwareCtl/firmwareCtl.ino
+++ b/software/firmwareCtl/firmwareCtl.ino
@@ -160,8 +160,10 @@ const int chipSelect = BUILTIN_SDCARD;
   const byte strArp_nStrPrsFnc=2;
   byte strArp_strPrsFnc=0;
   
-  const char* strArp_strEncNm[]={"steps", "tmDv"}; 
-  const byte strArp_nStrEncFnc=2;
+  const byte strArp_strEncFnc_stps=0;
+  const byte strArp_strEncFnc_tmDv=1;
+  const char* strArp_strEncNm[]={"steps", "tmDv"};
+  const byte strArp_nStrEncFnc=sizeof(strArp_strEncNm)/sizeof(strArp_strEncNm[0]);
   byte strArp_strEncFnc=0;
   
   const char* strArp_strBtnNm[]={"mute", "randomise"};
@@ -199,15 +201,15 @@ const int chipSelect = BUILTIN_SDCARD;
   const int genSq_maxStpV[genSq_nStrPrsFnc]={12,9,50,99,99,99};
   int genSq_strPrsFnc=0;
 
-  const char* genSq_strEncNm[]={"tmDv","offSt","stps","sync","chn"};
-  const int genSq_strEncFnc_stps=2;
   const int genSq_strEncFnc_tmDv=0;
   const int genSq_strEncFnc_offSt=1;
+  const int genSq_strEncFnc_stps=2;
   const int genSq_strEncFnc_sync=3;
   const int genSq_strEncFnc_chn=4;
+  const char* genSq_strEncNm[]={"tmDv","offSt","stps","sync","chn"};
 
-  const int genSq_nStrEncFnc=5;
-  const int genSeq_maxEncV[genSq_nStrPrsFnc]={genSq_nTmDvs,16,genSq_maxVisSteps,6,16};
+  const int genSq_nStrEncFnc=sizeof(genSq_strEncNm)/sizeof(genSq_strEncNm[0]);
+  const int genSeq_maxEncV[genSq_nStrEncFnc]={genSq_nTmDvs,16,genSq_maxVisSteps,6,16};
   int genSq_strEncFnc=0;
   int genSq_strEncChAStps=0;
 


### PR DESCRIPTION
### Motivation
- Make the string-encoder function mappings for `strArp` easy to expand and reorder and apply the same robust pattern already used for `genSeq` to avoid fragile magic numbers.
- Reduce maintenance burden by deriving counts from the name arrays so adding or reordering encoder functions does not require manually updating separate counts.

### Description
- Introduce named encoder-index constants for `strArp` (`strArp_strEncFnc_stps`, `strArp_strEncFnc_tmDv`) and derive `strArp_nStrEncFnc` from the `strArp_strEncNm` array instead of a hard-coded literal.
- Replace raw `0`/`1` checks/usages in `strArp_chStrEnc` and display logic with the new named constants for clearer intent and safer refactoring.
- Apply the same pattern to the generic sequencer (`genSeq`): ensure encoder index constants align with the `genSq_strEncNm` array, derive `genSq_nStrEncFnc` via `sizeof(...)`, and size `genSeq_maxEncV` from that derived count.
- Keep behavior-preserving changes only (no protocol, pin, timing, or audio routing changes). Files modified: `software/firmwareCtl/firmwareCtl.ino` and `software/firmwareCtl/09_op02_StrArp.ino`.

### Testing
- Ran repository scans and targeted diffs to confirm only intended lines changed and `git diff --check` produced no whitespace/merge errors; this check succeeded.
- Verified updated usages in `strArp_chStrEnc` and display rendering now reference the named constants instead of literals by inspecting `software/firmwareCtl/09_op02_StrArp.ino` and `software/firmwareCtl/firmwareCtl.ino`.
- Did not run a firmware build because Arduino/Teensy build tooling is not available in this environment; this check was not run.
- Did not run hardware validation on the ElektroCaster CTL board; this check was not run.

Affected files: `software/firmwareCtl/firmwareCtl.ino`, `software/firmwareCtl/09_op02_StrArp.ino`.

Checks not run: firmware compile/upload (`arduino-cli`/`platformio`), and hardware integration tests on the actual ElektroCaster device.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5765bc00908332aeff809b75e2989c)