### PR TITLE
Make strArp MIDI channel selectable via string encoder

### DIFF
--- a/software/firmwareCtl/09_op02_StrArp.ino
+++ b/software/firmwareCtl/09_op02_StrArp.ino
@@ -36,6 +36,9 @@ void strArp_chStrEnc(byte s, int val){
       strArp_tmDvSel[s] = (strArp_tmDvSel[s] + val)%strArp_nTmDvs;
       strArp_tmDv[s]=strArp_tmDvs[strArp_tmDvSel[s]];
       break;
+    case strArp_strEncFnc_chn:
+      strArp_chn[s] = constrain(strArp_chn[s] + val, 0, 16);
+      break;
   }
 }
 
@@ -81,6 +84,7 @@ void strArp_updDisp(){
   for(int s =0; s < nStrings;s++){
     if(strArp_strEncFnc==strArp_strEncFnc_stps)disp_Int(108-s*21, 55, strArp_nRpt[s]);
     if(strArp_strEncFnc==strArp_strEncFnc_tmDv)disp_Str(108-s*21, 55, strArp_tmDvNm[strArp_tmDvSel[s]]);
+    if(strArp_strEncFnc==strArp_strEncFnc_chn)disp_Int(108-s*21, 55, strArp_chn[s]);
   }
 
   disp_Color(1);
@@ -123,7 +127,7 @@ void strArp_updClck(){
 void strArp_updClckParallel(){
   for(int s=0;s<nStrings;s++){
     static int tmDv[nStrings];
-    int chnl = genSq_chn[0][0][s][genSq_strEncFnc_chn]; //midi channel is derived from first pattern of the firs instance of the genSeq
+    int chnl = strArp_chn[s];
     if(pulse != lastPulse && tmDv[s] != strArp_tmDv[s]){
       tmDv[s]=strArp_tmDv[s];
       strArp_nxtClkFil[s]=strArp_tmDv[s];
@@ -155,7 +159,7 @@ void strArp_silenceInactiveSerialNotes(){
 
   for(int i = 0; i<nStrings; i++){
     if(strPrs[i] == 0 || strArp_muteCh[i] == 1 || mtOut != 0 || strPrs[i] > nFrets-genSq_nPttn/2-1){
-      int chnl = genSq_chn[0][0][i][genSq_strEncFnc_chn];
+      int chnl = strArp_chn[i];
       sndMidiNotePress(i,0,chnl);
     }
   }
@@ -185,7 +189,7 @@ void strArp_updClckSerial(){
   // Time the next trigger from the currently playing step, not the upcoming one.
   byte durationString = s;
   if(strArp_serialDisplayStep >= 0)durationString=strArp_seq[strArp_serialDisplayStep];
-  int chnl = genSq_chn[0][0][s][genSq_strEncFnc_chn]; //midi channel is derived from first pattern of the firs instance of the genSeq
+  int chnl = strArp_chn[s];
 
   strArp_serialNxtClkFil++;
   
@@ -200,7 +204,7 @@ void strArp_updClckSerial(){
     if(frtb_sensMode==0){
       for(int i = 0; i<nStrings; i++){
         if(i != s){
-          int offChnl = genSq_chn[0][0][i][genSq_strEncFnc_chn];
+          int offChnl = strArp_chn[i];
           sndMidiNotePress(i,0,offChnl);
         }
       }

--- a/software/firmwareCtl/firmwareCtl.ino
+++ b/software/firmwareCtl/firmwareCtl.ino
@@ -153,6 +153,7 @@ const int chipSelect = BUILTIN_SDCARD;
   byte strArp_nTmDvs=12;
   byte strArp_nxtClkFil[nStrings];
   byte strArp_nRpt[nStrings] = {1,1,1,1,1,1};
+  byte strArp_chn[nStrings] = {1,1,1,1,1,1};
 
   const byte strArp_modeSerial=0;
   const byte strArp_modeParallel=1;
@@ -162,7 +163,8 @@ const int chipSelect = BUILTIN_SDCARD;
   
   const byte strArp_strEncFnc_stps=0;
   const byte strArp_strEncFnc_tmDv=1;
-  const char* strArp_strEncNm[]={"steps", "tmDv"};
+  const byte strArp_strEncFnc_chn=2;
+  const char* strArp_strEncNm[]={"steps", "tmDv", "chn"};
   const byte strArp_nStrEncFnc=sizeof(strArp_strEncNm)/sizeof(strArp_strEncNm[0]);
   byte strArp_strEncFnc=0;
   


### PR DESCRIPTION
### Motivation
- Allow the string arpeggiator (`strArp`) to send notes on a per-string MIDI channel selected by the user rather than borrowing the channel from the GenSeq pattern, making channel routing explicit and user-configurable.
- Expose channel selection through the existing string-encoder UI so each string's channel can be adjusted live from the encoder controls.

### Description
- Add a per-string `strArp_chn[nStrings]` array initialized to channel 1 and a new encoder function `strArp_strEncFnc_chn` with display name `"chn"` in `firmwareCtl.ino`.
- Implement encoder handling for the `chn` function in `strArp_chStrEnc()` using `constrain(..., 0, 16)` to clamp values to the existing channel range.
- Update the strArp display to show each string's selected channel when the encoder function is `chn` in `09_op02_StrArp.ino`.
- Route serial and parallel note-on/note-off handling and inactive-note silencing to use `strArp_chn[s]` instead of deriving the channel from `genSq_chn[...]` in `09_op02_StrArp.ino`.

### Testing
- Ran `git diff --check` which reported no whitespace or patch errors and succeeded. 
- Ran targeted search checks with `rg` to confirm new symbols and replacements (`strArp_chn`, `strArp_strEncFnc_chn`, display call changes), which succeeded and matched the intended edits.
- Not run: firmware build because `arduino-cli`/PlatformIO is not available in this environment. 
- Not run: hardware validation (requires ElektroCaster CTL board, MIDI target, and encoders) and automated compile-time checks on the target toolchain.

Affected files: `software/firmwareCtl/firmwareCtl.ino`, `software/firmwareCtl/09_op02_StrArp.ino`.
Checks not run: `arduino-cli compile` / `platformio run` and on-device hardware tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57a3777854833285f50fdfef3fcfd6)