### PR TITLE
Schedule parallel string arp lanes

### DIFF
--- a/software/firmwareCtl/09_op02_StrArp.ino
+++ b/software/firmwareCtl/09_op02_StrArp.ino
@@ -224,11 +224,13 @@ void strArp_updClckSerial(){
         }
       }
     }
-    if(frtb_sensMode==0 && strPrs[s]==0)sndMidiNotePress(s,0,chnl);
-    if(strPrs[s] > 0 && strArp_muteCh[s]==0 && mtOut==0 && strPrs[s]<=nFrets-genSq_nPttn/2-1){
-      if(frtb_sensMode==0)sndMidiNotePress(s,strPrs[s],chnl);
-      sndTrigEnv(s, 1);
-      kick(s);
+    if(strArp_mode[s] == strArp_modeSerial){
+      if(frtb_sensMode==0 && strPrs[s]==0)sndMidiNotePress(s,0,chnl);
+      if(strPrs[s] > 0 && strArp_muteCh[s]==0 && mtOut==0 && strPrs[s]<=nFrets-genSq_nPttn/2-1){
+        if(frtb_sensMode==0)sndMidiNotePress(s,strPrs[s],chnl);
+        sndTrigEnv(s, 1);
+        kick(s);
+      }
     }
     strArp_serialDisplayStep=strArp_serialStep;
     strArp_serialStep++;
@@ -325,7 +327,7 @@ void strArp_mkArp(){
 
   //calculate size of the sequence
   for(int s=0;s<nStrings;s++){
-    if(strPrs[s]>0 && strArp_mode[s] == strArp_modeSerial){
+    if(strPrs[s]>0){
       for(int r=0;r<strArp_nRpt[s] && arpSize<strArp_maxSteps;r++){
         arpSize++;
       }
@@ -337,7 +339,7 @@ void strArp_mkArp(){
   //-----make arp sequence by string order
   if(1){
     for(int s=0;s<nStrings;s++){
-      if(strPrs[s]>0 && strArp_mode[s] == strArp_modeSerial){
+      if(strPrs[s]>0){
         for(int r=0;r<strArp_nRpt[s] && arpIdx<strArp_maxSteps;r++){
           arpSeq[arpIdx]=s;
           arpIdx++;
@@ -375,15 +377,8 @@ void strArp_mkArp(){
   for(int i=0;i<arpSize;i++){
   strArp_stp[arpSeq[i]][i]=1;  
   }
-  //---parallel strings keep independent one-step lanes----
-  for(int s=0;s<nStrings;s++){
-    if(strPrs[s]>0 && strArp_mode[s] == strArp_modeParallel){
-      strArp_stp[s][0]=1;
-    }
-  }
   //---set seq length----
   for(int s=0;s<nStrings;s++){
-    if(strArp_mode[s] == strArp_modeParallel)strArp_nStps[s]=1;
-    else strArp_nStps[s]=arpSize;
+    strArp_nStps[s]=arpSize;
   }
 }


### PR DESCRIPTION
### Motivation

- Ensure strings configured in parallel mode are still included in the generated string arp sequence so they are scheduled by the shared arp rather than given isolated one-step lanes. 
- Preserve per-string timing behavior so parallel strings can naturally drift when their `tmDv` values differ while preventing the serial scheduler from directly triggering parallel-mode strings.

### Description

- Changed `strArp_mkArp()` in `software/firmwareCtl/09_op02_StrArp.ino` to include any pressed string in the generated arp sequence regardless of its `strArp_mode`, and to set `strArp_nStps` uniformly to the generated `arpSize` for all strings. 
- Removed the previous special-case that gave `strArp_modeParallel` strings an independent one-step lane and the associated step initialization. 
- Modified `strArp_updClckSerial()` to avoid emitting note/trigger actions for a string when that string is currently set to `strArp_modeParallel`, so the serial sequencer will not directly trigger parallel-mode strings while stepping the shared sequence.

### Testing

- Ran `git diff --check` which reported no diff/whitespace errors and the change was committed successfully. 
- Affected file: `software/firmwareCtl/09_op02_StrArp.ino`.
- Not run: firmware compile/build (Teensy/Arduino toolchain), hardware timing and behavior validation on ElektroCaster boards, and any automated unit or integration tests that require device hardware.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58851b8b3c8332991a25d4ccbf792e)