### PR TITLE
Sync string arp parallel clocks

### DIFF
--- a/software/firmwareCtl/09_op02_StrArp.ino
+++ b/software/firmwareCtl/09_op02_StrArp.ino
@@ -182,7 +182,28 @@ void strArp_resetSerialCursor(){
   if(strArp_seqLen > 0)strArp_serialNxtClkFil=strArp_tmDv[strArp_seq[0]];
 }
 
+byte strArp_serialDurationString(){
+  if(strArp_seqLen == 0)return 0;
+  if(strArp_serialDisplayStep >= 0 && strArp_serialDisplayStep < strArp_seqLen)return strArp_seq[strArp_serialDisplayStep];
+  byte step = strArp_serialStep;
+  if(step >= strArp_seqLen)step=0;
+  return strArp_seq[step];
+}
+
+void strArp_syncParallelClocksToSerial(){
+  if(strArp_seqLen == 0)return;
+
+  byte durationString = strArp_serialDurationString();
+  byte serialTmDv = strArp_tmDv[durationString];
+  for(int s = 0; s<nStrings; s++){
+    if(strArp_mode[s] != strArp_modeParallel)continue;
+    if(strArp_tmDv[s] != serialTmDv)continue;
+    strArp_nxtClkFil[s]=strArp_serialNxtClkFil;
+  }
+}
+
 void strArp_updClckHybrid(){
+  strArp_syncParallelClocksToSerial();
   strArp_updClckParallelMode(strArp_modeParallel);
   strArp_updClckSerial();
 }


### PR DESCRIPTION
### Motivation
- Keep parallel-mode string arpeggiator clocks phase-aligned with the serial-mode sequence when they use the same `tmDv`, so same-tempo strings behave as if driven by a shared clock while allowing independent timing when `tmDv` differs.

### Description
- Add `strArp_serialDurationString()` and `strArp_syncParallelClocksToSerial()` and call the sync from `strArp_updClckHybrid()` so parallel-mode strings whose `strArp_tmDv` matches the active serial duration copy the serial filter/phase (`strArp_serialNxtClkFil -> strArp_nxtClkFil[s]`).
- Change is limited to `software/firmwareCtl/09_op02_StrArp.ino` (21-line insertion).

### Testing
- Ran `git diff --check` and `git status --short`, and created the commit; those checks succeeded.
- Did not run firmware builds (`platformio`/`arduino-cli`) or any hardware timing/behavior tests in this environment; affected file: `software/firmwareCtl/09_op02_StrArp.ino`; checks not run: `platformio`/`arduino-cli` compile and on-device timing/hardware validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5887ff82208332a641d3c74fe5ae1e)