### PR TITLE
Sync parallel-mode string clocks to serial arpeggiator and add serial duration helper

### DIFF
--- a/software/firmwareCtl/09_op02_StrArp.ino
+++ b/software/firmwareCtl/09_op02_StrArp.ino
@@ -182,7 +182,30 @@ void strArp_resetSerialCursor(){
   if(strArp_seqLen > 0)strArp_serialNxtClkFil=strArp_tmDv[strArp_seq[0]];
 }
 
+byte strArp_serialDurationString(){
+  if(strArp_seqLen == 0)return 0;
+  if(strArp_serialDisplayStep >= 0 && strArp_serialDisplayStep < strArp_seqLen)return strArp_seq[strArp_serialDisplayStep];
+  byte step = strArp_serialStep;
+  if(step >= strArp_seqLen)step=0;
+  return strArp_seq[step];
+}
+
+void strArp_syncParallelClocksToSerial(){
+  if(strArp_seqLen == 0)return;
+
+  byte durationString = strArp_serialDurationString();
+  byte serialTmDv = strArp_tmDv[durationString];
+  for(int s = 0; s<nStrings; s++){
+    if(strArp_mode[s] != strArp_modeParallel)continue;
+    if(strArp_tmDv[s] != serialTmDv)continue;
+    strArp_nxtClkFil[s]=strArp_serialNxtClkFil;
+    strArp_clk[s]=strArp_serialStep;
+    if(strArp_clk[s]>=strArp_nStps[s])strArp_clk[s]=0;
+  }
+}
+
 void strArp_updClckHybrid(){
+  strArp_syncParallelClocksToSerial();
   strArp_updClckParallelMode(strArp_modeParallel);
   strArp_updClckSerial();
 }


### PR DESCRIPTION
### Motivation

- Ensure parallel-mode strings that share the same time division stay locked to the currently playing serial arpeggiator step when running in hybrid mode.
- Provide a small helper to determine the serial sequence's current duration index for use when synchronizing clocks.

### Description

- Added `strArp_serialDurationString()` which returns the current serial sequence step index (preferring the display step when active) and gracefully handles an empty sequence.
- Added `strArp_syncParallelClocksToSerial()` which aligns `strArp_nxtClkFil` and `strArp_clk` of parallel-mode strings to the serial cursor when their `strArp_tmDv` matches the serial step's time division, with bounds checking against `strArp_nStps`.
- Integrated synchronization by calling `strArp_syncParallelClocksToSerial()` at the start of `strArp_updClckHybrid()` so hybrid-mode updates keep parallel strings in phase with the serial sequence.

### Testing

- Project firmware was built after the change and the build completed successfully with no compile errors.
- Existing automated checks (build) passed and no test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5887ff82208332a641d3c74fe5ae1e)