### PR TITLE
Honor press timing in strArp string ordering

### DIFF
--- a/software/firmwareCtl/04_hid.ino
+++ b/software/firmwareCtl/04_hid.ino
@@ -67,6 +67,7 @@ bool emitFretEvents(int *eventString, int *eventPress) {
 void handleFretEventForAudioMidiKickSeq(int eventString, int eventPress, int sensMode) {
   int s = eventString;
   int press = eventPress;
+  strArp_notePressOrder(s, press);
   int chnl = genSq_chn[0][genSq_actPttn[0]][s][genSq_strEncFnc_chn];
 
   if (strHold[s]==0||genSq_muteCh[0][s]){

--- a/software/firmwareCtl/09_op02_StrArp.ino
+++ b/software/firmwareCtl/09_op02_StrArp.ino
@@ -141,6 +141,52 @@ void strArp_resetSerialCursor(){
   if(strArp_seqLen > 0)strArp_serialNxtClkFil=strArp_tmDv[strArp_seq[0]];
 }
 
+void strArp_notePressOrder(byte s, int press){
+  if(press > 0){
+    if(strArp_pressOrder[s] == 0){
+      strArp_pressOrder[s] = strArp_pressOrderNext;
+      strArp_pressOrderNext++;
+    }
+  }
+  else{
+    strArp_pressOrder[s] = 0;
+    bool anyPressed=0;
+    for(int i=0;i<nStrings;i++){
+      if(strArp_pressOrder[i]>0)anyPressed=1;
+    }
+    if(!anyPressed)strArp_pressOrderNext=1;
+  }
+}
+
+unsigned int strArp_orderGroupPressOrder(byte order){
+  unsigned int groupPressOrder=0;
+  for(int s=0;s<nStrings;s++){
+    if(strPrs[s]>0 && strArp_order[s]==order && strArp_pressOrder[s]>0){
+      if(groupPressOrder==0 || strArp_pressOrder[s]<groupPressOrder)groupPressOrder=strArp_pressOrder[s];
+    }
+  }
+  return groupPressOrder;
+}
+
+void strArp_addStringToArp(byte arpSeq[], int *arpIdx, byte s){
+  for(int r=0;r<strArp_nRpt[s] && *arpIdx<strArp_maxSteps;r++){
+    arpSeq[*arpIdx]=s;
+    (*arpIdx)++;
+  }
+}
+
+void strArp_addPressedZeroOrderStrings(byte arpSeq[], int *arpIdx, bool zeroOrderAdded[], unsigned int beforePressOrder, bool addRemaining){
+  for(unsigned int pressed=1;pressed<strArp_pressOrderNext;pressed++){
+    for(int s=0;s<nStrings;s++){
+      if(strPrs[s]>0 && strArp_order[s]==0 && strArp_pressOrder[s]==pressed && !zeroOrderAdded[s]){
+        if(addRemaining || pressed<beforePressOrder){
+          strArp_addStringToArp(arpSeq, arpIdx, s);
+          zeroOrderAdded[s]=1;
+        }
+      }
+    }
+  }
+}
 
 bool strArp_isSameOrderGroup(byte a, byte b){
   return a != b && strArp_order[a] > 0 && strArp_order[a] == strArp_order[b];
@@ -306,28 +352,22 @@ void strArp_mkArp(){
   arpSize=0; //reset arp size
 
   int arpIdx=0;
+  bool zeroOrderAdded[nStrings];
+  for(int s=0;s<nStrings;s++)zeroOrderAdded[s]=0;
 
   //-----make arp sequence by configurable string order
   if(1){
     for(int order=1;order<=nStrings;order++){
+      unsigned int groupPressOrder=strArp_orderGroupPressOrder(order);
+      if(groupPressOrder>0)strArp_addPressedZeroOrderStrings(arpSeq, &arpIdx, zeroOrderAdded, groupPressOrder, 0);
       for(int s=0;s<nStrings;s++){
         if(strPrs[s]>0 && strArp_order[s]==order){
-          for(int r=0;r<strArp_nRpt[s] && arpIdx<strArp_maxSteps;r++){
-            arpSeq[arpIdx]=s;
-            arpIdx++;
-          }
+          strArp_addStringToArp(arpSeq, &arpIdx, s);
           break;
         }
       }
     }
-    for(int s=0;s<nStrings;s++){
-      if(strPrs[s]>0 && strArp_order[s]==0){
-        for(int r=0;r<strArp_nRpt[s] && arpIdx<strArp_maxSteps;r++){
-          arpSeq[arpIdx]=s;
-          arpIdx++;
-        }
-      }
-    }
+    strArp_addPressedZeroOrderStrings(arpSeq, &arpIdx, zeroOrderAdded, 0, 1);
   }
 
   arpSize=arpIdx;

--- a/software/firmwareCtl/firmwareCtl.ino
+++ b/software/firmwareCtl/firmwareCtl.ino
@@ -165,6 +165,8 @@ const int chipSelect = BUILTIN_SDCARD;
   byte strArp_nRpt[nStrings] = {1,1,1,1,1,1};
   byte strArp_chn[nStrings] = {1,1,1,1,1,1};
   byte strArp_order[nStrings] = {0,0,0,0,0,0};
+  unsigned int strArp_pressOrder[nStrings] = {0,0,0,0,0,0};
+  unsigned int strArp_pressOrderNext = 1;
 
   const byte strArp_modeSerial=0;
   const byte strArp_modeParallel=1;


### PR DESCRIPTION
### Motivation
- Allow the string arpeggiator to respect the relative order in which strings are pressed so order-0 (unassigned) strings can be merged into the configured order sequence based on press timing while preserving existing behavior for ordered strings.

### Description
- Add per-string press-order state with `strArp_pressOrder[]` and `strArp_pressOrderNext` to record the relative time a string was pressed. 
- Add `strArp_notePressOrder()` and wire it into the existing fret-event path so press/release markers are tracked without changing debounce or scan logic. 
- Rework sequence construction in `strArp_mkArp()` to merge order-0 strings by press timing using helpers `strArp_orderGroupPressOrder()`, `strArp_addStringToArp()` and `strArp_addPressedZeroOrderStrings()` while reusing the existing repeat logic. 
- Keep the prior repeat/flip/mirror behavior and the configured `strArp_order[]` semantics for strings with order > 0.

### Testing
- Ran `git diff --check` to validate diffs and spacing which completed with no errors. 
- Firmware build/upload was not run because the local toolchain (`arduino-cli`/`platformio`) is not available in this environment. 
- No physical hardware tests (fretboard, MIDI, LED, Kickup) were run because the ElektroCaster hardware is not available here. 
- Affected files: `software/firmwareCtl/firmwareCtl.ino`, `software/firmwareCtl/04_hid.ino`, `software/firmwareCtl/09_op02_StrArp.ino`.
- Checks not run: firmware compile/link (`arduino-cli`/`platformio`) and physical integration tests (fretboard press timing, serial MIDI/audio behavior, LED/Kickup verification).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58fd82a528833295eb5475bda4564e)