### PR TITLE
Support multiple string-press functions (simple/back/flip/mirror) and apply them in arpeggio construction

### DIFF
--- a/software/firmwareCtl/09_op02_StrArp.ino
+++ b/software/firmwareCtl/09_op02_StrArp.ino
@@ -338,15 +338,15 @@ void strArp_drwStep(){
 }
 
 void strArp_mkArp(){
-  byte flip=1;
+  byte back=0;
+  byte flip=0;
   byte mirror=0;
   byte arpSize=0;
   byte arpSeq[64];
 
-
-//  if(arpMode==2||arpMode==3||arpMode==6||arpMode==7)orderSrc=1;
-//  if(arpMode==1||arpMode==3||arpMode==5||arpMode==7)flip=1;
-//  if(arpMode==4||arpMode==5||arpMode==6||arpMode==7)mirror=1;
+  if(strArp_strPrsFnc==strArp_strPrsFnc_back)back=1;
+  if(strArp_strPrsFnc==strArp_strPrsFnc_flip)flip=1;
+  if(strArp_strPrsFnc==strArp_strPrsFnc_mirror)mirror=1;
 
   strArp_ersStps(); //clear the sequence
   arpSize=0; //reset arp size
@@ -372,14 +372,20 @@ void strArp_mkArp(){
 
   arpSize=arpIdx;
 
-  //----flip sequence----
-  if(flip==1){
+  //----back sequence----
+  if(back==1){
     byte seqbuf[arpSize];
     for(int i=0;i<arpSize;i++){
       seqbuf[i]=arpSeq[arpSize-i-1];
     }
     for(int i=0;i<arpSize;i++){
       arpSeq[i]=seqbuf[i];
+    }
+  }
+
+  if(flip==1){
+    for(int i=0;i<arpSize;i++){
+      arpSeq[i]=nStrings-arpSeq[i]-1;
     }
   }
 

--- a/software/firmwareCtl/firmwareCtl.ino
+++ b/software/firmwareCtl/firmwareCtl.ino
@@ -165,6 +165,7 @@ const int chipSelect = BUILTIN_SDCARD;
   byte strArp_nRpt[nStrings] = {1,1,1,1,1,1};
   byte strArp_chn[nStrings] = {1,1,1,1,1,1};
   byte strArp_order[nStrings] = {0,0,0,0,0,0};
+
   unsigned int strArp_pressOrder[nStrings] = {0,0,0,0,0,0};
   unsigned int strArp_pressOrderNext = 1;
 
@@ -172,9 +173,13 @@ const int chipSelect = BUILTIN_SDCARD;
   const byte strArp_modeParallel=1;
   const char* strArp_modeNm[]={"se", "pa"};
   byte strArp_mode[nStrings]={strArp_modeSerial,strArp_modeSerial,strArp_modeSerial,strArp_modeSerial,strArp_modeSerial,strArp_modeSerial};
-  const char* strArp_strPrsNm[]={"mode"};
-  const byte strArp_nStrPrsFnc=1;
-  byte strArp_strPrsFnc=0;
+  const byte strArp_strPrsFnc_simple=0;
+  const byte strArp_strPrsFnc_back=1;
+  const byte strArp_strPrsFnc_flip=2;
+  const byte strArp_strPrsFnc_mirror=3;
+  const char* strArp_strPrsNm[]={"simple", "back", "flip", "mirror"};
+  const byte strArp_nStrPrsFnc=sizeof(strArp_strPrsNm)/sizeof(strArp_strPrsNm[0]);
+  byte strArp_strPrsFnc=strArp_strPrsFnc_simple;
   
   const byte strArp_strEncFnc_stps=0;
   const byte strArp_strEncFnc_tmDv=1;


### PR DESCRIPTION
### Motivation
- Introduce configurable string-press behaviors to allow reversing, flipping and mirroring of generated arpeggio sequences.
- Replace prior hardcoded/commented logic with explicit, named modes to make sequence transforms clearer and selectable at runtime.

### Description
- Add new press-function constants `strArp_strPrsFnc_simple`, `strArp_strPrsFnc_back`, `strArp_strPrsFnc_flip`, and `strArp_strPrsFnc_mirror`, plus the `strArp_strPrsNm` array and computed `strArp_nStrPrsFnc`, and set the default `strArp_strPrsFnc` to `simple`.
- Update `strArp_mkArp()` to derive `back`, `flip`, and `mirror` flags from `strArp_strPrsFnc` and apply the transforms to the temporary `arpSeq`: `back` reverses the whole sequence, `flip` inverts string indices via `arpSeq[i] = nStrings - arpSeq[i] - 1`, and `mirror` appends a reversed copy of the sequence to itself.
- Add local `byte back` variable and relocate/clean up the previous flip/mirror handling; remove legacy commented mode-mapping code and keep the rest of sequence copying and sequencer setup unchanged.

### Testing
- Performed an automated build/compile of the firmware sketch files (`firmwareCtl.ino` and `09_op02_StrArp.ino`) which completed successfully.
- No automated unit tests were present or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59ccacabac8332be5c6dc4681aa53f)