### PR TITLE
Replace strArp "flip" mode with "rev mirror" and add reversed-mirror behavior

### DIFF
--- a/software/firmwareCtl/09_op02_StrArp.ino
+++ b/software/firmwareCtl/09_op02_StrArp.ino
@@ -339,14 +339,14 @@ void strArp_drwStep(){
 
 void strArp_mkArp(){
   byte back=0;
-  byte flip=0;
   byte mirror=0;
+  byte revMirror=0;
   byte arpSize=0;
   byte arpSeq[64];
 
   if(strArp_strPrsFnc==strArp_strPrsFnc_back)back=1;
-  if(strArp_strPrsFnc==strArp_strPrsFnc_flip)flip=1;
   if(strArp_strPrsFnc==strArp_strPrsFnc_mirror)mirror=1;
+  if(strArp_strPrsFnc==strArp_strPrsFnc_revMirror)revMirror=1;
 
   strArp_ersStps(); //clear the sequence
   arpSize=0; //reset arp size
@@ -383,16 +383,20 @@ void strArp_mkArp(){
     }
   }
 
-  if(flip==1){
-    for(int i=0;i<arpSize;i++){
-      arpSeq[i]=nStrings-arpSeq[i]-1;
-    }
-  }
-
-  if(mirror==1){
+  if(mirror==1 || revMirror==1){
     int baseSize=arpSize;
+    byte seqbuf[baseSize];
+    for(int i=0;i<baseSize;i++){
+      seqbuf[i]=arpSeq[i];
+    }
+    if(revMirror==1){
+      for(int i=0;i<baseSize;i++){
+        arpSeq[i]=seqbuf[baseSize-i-1];
+      }
+    }
     for(int i=0;i<baseSize && arpSize<strArp_maxSteps;i++){
-      arpSeq[baseSize+i]=arpSeq[baseSize-i-1];
+      arpSeq[baseSize+i]=seqbuf[baseSize-i-1];
+      if(revMirror==1)arpSeq[baseSize+i]=seqbuf[i];
       arpSize++;
     }
   }

--- a/software/firmwareCtl/firmwareCtl.ino
+++ b/software/firmwareCtl/firmwareCtl.ino
@@ -175,9 +175,9 @@ const int chipSelect = BUILTIN_SDCARD;
   byte strArp_mode[nStrings]={strArp_modeSerial,strArp_modeSerial,strArp_modeSerial,strArp_modeSerial,strArp_modeSerial,strArp_modeSerial};
   const byte strArp_strPrsFnc_simple=0;
   const byte strArp_strPrsFnc_back=1;
-  const byte strArp_strPrsFnc_flip=2;
-  const byte strArp_strPrsFnc_mirror=3;
-  const char* strArp_strPrsNm[]={"simple", "back", "flip", "mirror"};
+  const byte strArp_strPrsFnc_mirror=2;
+  const byte strArp_strPrsFnc_revMirror=3;
+  const char* strArp_strPrsNm[]={"simple", "back", "mirror", "rev mirror"};
   const byte strArp_nStrPrsFnc=sizeof(strArp_strPrsNm)/sizeof(strArp_strPrsNm[0]);
   byte strArp_strPrsFnc=strArp_strPrsFnc_simple;
   


### PR DESCRIPTION
### Motivation
- Simplify and change the string-press arpeggiator modes by removing the old "flip" behavior and providing a mirrored variant that plays the mirrored pattern in reverse-first order.

### Description
- Replaced the `flip` press mode with a new `rev mirror` mode label and adjusted the `strArp_strPrsFnc` constants and name table in `firmwareCtl.ino`.
- Updated `strArp_mkArp()` in `09_op02_StrArp.ino` to remove the old `flip` transformation and implement `revMirror` so that `mirror` preserves the original-then-reflected sequence while `revMirror` produces a reversed-first mirrored sequence.
- Preserved existing `back` and `mirror` behaviors and ensured the arpeggio sequence buffer handling limits remain unchanged.
- Changes are localized to the CTL firmware arpeggiator logic and display name used for the selectable mode.

### Testing
- Ran a repository search for references and the new identifiers with `rg -n "strArp_strPrsFnc_flip|\bflip\b|revMirror|rev mirror"` and confirmed occurrences were updated; the search returned only the updated locations (succeeded).
- Ran `git diff --check` and `git status --short` to verify no whitespace errors and that the two modified files are staged and committed (succeeded).
- Not run: firmware compile or upload to the Teensy/Arduino environment because toolchain/board access is not available in this environment.
- Not run: any hardware validation (CTL board behavior, LED fretboard, real-time arpeggiator/press-order interaction) which require physical devices.

Affected files: `software/firmwareCtl/firmwareCtl.ino`, `software/firmwareCtl/09_op02_StrArp.ino`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59d0d77d4083328d020bf6dbe0d43d)