### PR TITLE
Schedule genSeq/strArp mode switches on clock pulses

### DIFF
--- a/software/firmwareCtl/02_clock.ino
+++ b/software/firmwareCtl/02_clock.ino
@@ -47,6 +47,11 @@ void cmpClck(long mClock){
   pulse=mClock/24;
   bar=mClock/96;
   syncPnt=mClock/syncInt;
+  if(schdStrArpModeSel > -1 && pulse != lastPulse){
+    strArp_modeSel = schdStrArpModeSel;
+    updStrAutoMode();
+    schdStrArpModeSel = -1;
+  }
   if(schdStrArpPttnCh > -1 && pulse != lastPulse){
     strArp_nxtPttn = schdStrArpPttnCh;
     strArp_actPttn = strArp_nxtPttn;

--- a/software/firmwareCtl/04_hid.ino
+++ b/software/firmwareCtl/04_hid.ino
@@ -367,8 +367,7 @@ void procHidRChng(byte idx, byte val) {
   switch (idx) {
     case 0:
       if(val<genSq_nPttn){
-        strArp_modeSel = 0;
-        updStrAutoMode();
+        schdStrArpModeSel = 0;
         //if(opMode==strArp_opMode)chOpMode(genSq_opMode);
         if(shift==0){
           schdPttnCh[idx]=val;
@@ -388,11 +387,10 @@ void procHidRChng(byte idx, byte val) {
         }
       }
       if(val>=genSq_nPttn){
-        strArp_modeSel = 1;
         strArp_modeVal = val;
+        schdStrArpModeSel = 1;
         schdStrArpPttnCh = 11 - val;
         if(schdStrArpPttnCh >= strArp_nPttn)schdStrArpPttnCh = 0;
-        updStrAutoMode();
         //if(opMode==genSq_opMode)chOpMode(strArp_opMode);
       }
       break;

--- a/software/firmwareCtl/firmwareCtl.ino
+++ b/software/firmwareCtl/firmwareCtl.ino
@@ -161,6 +161,7 @@ const int chipSelect = BUILTIN_SDCARD;
   byte strArp_actPttn = 0;
   byte strArp_nxtPttn = 0;
   int schdStrArpPttnCh = -1;
+  int schdStrArpModeSel = -1;
   StrArpPatternBank strArp_patterns;
 
   #define strArp_tmDv strArp_patterns.pttn[strArp_actPttn].tmDv


### PR DESCRIPTION
### Motivation
- Prevent immediate mode flips when the selector moves between `genSeq` and `strArp` ranges so mode changes occur synchronized to the internal clock pulse boundary. 
- Keep pattern scheduling behavior deterministic by applying mode selection at the same scheduled timing as existing pattern switches.

### Description
- Add a pending mode selection variable `schdStrArpModeSel` in `software/firmwareCtl/firmwareCtl.ino` to queue genSeq/strArp mode changes. 
- Change the HID handler in `software/firmwareCtl/04_hid.ino` to write `schdStrArpModeSel` instead of flipping `strArp_modeSel` immediately when the selector crosses between `genSeq` and `strArp` ranges. 
- Apply the pending mode change in the clock comparison path in `software/firmwareCtl/02_clock.ino` on the next pulse by setting `strArp_modeSel`, calling `updStrAutoMode()`, and clearing the scheduled flag. 
- Preserve existing queued pattern scheduling (`schdStrArpPttnCh`) and pattern-sync logic so pattern selection remains on the same scheduled path.

### Testing
- Ran `git diff --check` and it produced no problems. 
- Affected files: `software/firmwareCtl/firmwareCtl.ino`, `software/firmwareCtl/02_clock.ino`, and `software/firmwareCtl/04_hid.ino`. 
- Checks not run: firmware compile/build for Teensy/Arduino, upload/hardware validation, and any unit or integration tests and static analysis were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a89a7acf48332bd0dc46ccd2df116)