### PR TITLE
Centralize LED color palettes and replace hardcoded colors with per-mode/mute constants

### DIFF
--- a/software/firmwareCtl/05_ledfrets.ino
+++ b/software/firmwareCtl/05_ledfrets.ino
@@ -54,13 +54,13 @@ void genSq_updPttnFleds(){
 void genSq_pttnDrwGrid(){ 
   int inst=genSq_actInst;
   for(int i=0;i<genSq_nInst;i++){
-    float brght;
-    if(inst!=genSq_nInst-i-1)brght=1;
-    if(inst==genSq_nInst-i-1)brght=5;
     for(int s=0;s<nStrings;s++){
       for(int f=0;f<genSq_nPttn/2;f++){
         for(int c=0;c<3;c++){  
-          if(s==i*2+1||s==i*2)genSq_pttnGridPix[s][f][c]=genSq_gridColor[genSq_nInst-i-1][c]*brght;
+          if(s==i*2+1||s==i*2){
+            if(inst==genSq_nInst-i-1)genSq_pttnGridPix[s][f][c]=genSq_gridColorA[genSq_nInst-i-1][c];
+            else genSq_pttnGridPix[s][f][c]=genSq_gridColorB[genSq_nInst-i-1][c];
+          }
         }
       }
     }

--- a/software/firmwareCtl/09_op02_StrArp.ino
+++ b/software/firmwareCtl/09_op02_StrArp.ino
@@ -281,21 +281,16 @@ void strArp_updFleds(){
 }
 
 void strArp_drwGrid(){
-  float colorA[3]={0.5,0,0};
-  float colorB[3]={0.05,0,0};
-  float colorMA[3]={0.1,0,0};
-  float colorMB[3]={0.02,0,0};
-
   for(int s=0;s<nStrings;s++){
     for(int f=0;f<strArp_maxVisSteps;f++){
       for(int c=0;c<3;c++){    
         if(f%4==0){
-          if(strArp_muteCh[s]==0)strArp_gridPix[s][f][c]=colorA[c];
-          else strArp_gridPix[s][f][c]=colorMA[c];
+          if(strArp_muteCh[s]==0)strArp_gridPix[s][f][c]=strArp_gridColorA[c];
+          else strArp_gridPix[s][f][c]=strArp_gridMuteColorA[c];
         }
         if(f%4 != 0){
-          if(strArp_muteCh[s]==0)strArp_gridPix[s][f][c]=colorB[c];
-          else strArp_gridPix[s][f][c]=colorMB[c];
+          if(strArp_muteCh[s]==0)strArp_gridPix[s][f][c]=strArp_gridColorB[c];
+          else strArp_gridPix[s][f][c]=strArp_gridMuteColorB[c];
         }
       }
     }
@@ -304,7 +299,6 @@ void strArp_drwGrid(){
 
 
 void strArp_drwCursor(){
-  float color[3] = {0,1,0};
   for(int s=0;s<nStrings;s++){
     for(int f=0;f<strArp_maxVisSteps;f++){
       for(int c=0;c<3;c++){    
@@ -314,20 +308,18 @@ void strArp_drwCursor(){
     }
    for(int s=0;s<nStrings;s++){
     for(int c=0;c<3;c++){    
-      if(strArp_clk[s]>=0 && strArp_clk[s]<strArp_maxVisSteps)strArp_crsrPix[s][strArp_clk[s]][c]=color[c];
+      if(strArp_clk[s]>=0 && strArp_clk[s]<strArp_maxVisSteps)strArp_crsrPix[s][strArp_clk[s]][c]=strArp_cursorColor[c];
     }
   }
 }
 
 void strArp_drwStep(){
-  float color[3] = {1,0,1};
-  float colorM[3] = {0.2,0.2,0.2};
   for(int s=0;s<nStrings;s++){
     for(int f=0;f<strArp_maxVisSteps;f++){
       for(int c=0;c<3;c++){    
         if(strArp_stp[s][f]==1){
-          if(strArp_muteCh[s]==0)strArp_stpPix[s][f][c]=color[c];
-          if(strArp_muteCh[s]==1)strArp_stpPix[s][f][c]=colorM[c];
+          if(strArp_muteCh[s]==0)strArp_stpPix[s][f][c]=strArp_stepColor[c];
+          if(strArp_muteCh[s]==1)strArp_stpPix[s][f][c]=strArp_stepMuteColor[c];
         }
         if(strArp_stp[s][f]==0){
           strArp_stpPix[s][f][c]=0;

--- a/software/firmwareCtl/10_op_genSq_Disp.ino
+++ b/software/firmwareCtl/10_op_genSq_Disp.ino
@@ -6,8 +6,6 @@ void genSq_updFleds(){
   for(int s=0;s<nStrings;s++){
     genSq_drwStep(s);
     genSq_drwCursor(s);
-    int muteCh=genSq_muteCh[inst][s];
-    
     for(int f=0;f<genSq_maxVisSteps;f++){
       bool stpOnOff=genSq_stpOnOff[inst][pttn][s][f];
       for(int ch=0;ch < 3; ch++){
@@ -15,9 +13,6 @@ void genSq_updFleds(){
       }
       if(stpOnOff>0)for(int ch=0;ch < 3; ch++){
         trgtC[s][f+1][ch]=genSq_stpPix[s][f][ch]+genSq_crsrPix[s][f][ch];
-      }
-      if(muteCh==1)for(int ch=0;ch < 3; ch++){
-        trgtC[s][f+1][ch]=trgtC[s][f+1][ch]*0.1;     
       }
     }
   }        
@@ -34,10 +29,12 @@ void genSq_drwGrid(){
       for(int c=0;c<3;c++){  
         genSq_gridPix[s][f][c]=0;  
         if((f%4==0 && f>=off && f<nSteps+off) || f<off+nSteps-genSq_maxVisSteps){
-          genSq_gridPix[s][f][c]=genSq_gridColor[inst][c]*5;
+          if(genSq_muteCh[inst][s]==0)genSq_gridPix[s][f][c]=genSq_gridColorA[inst][c];
+          else genSq_gridPix[s][f][c]=genSq_gridMuteColorA[inst][c];
         }
         if((f%4 != 0 && f>=off && f<nSteps+off) || f<off+nSteps-genSq_maxVisSteps){
-          genSq_gridPix[s][f][c]=genSq_gridColor[inst][c];
+          if(genSq_muteCh[inst][s]==0)genSq_gridPix[s][f][c]=genSq_gridColorB[inst][c];
+          else genSq_gridPix[s][f][c]=genSq_gridMuteColorB[inst][c];
         }
       }
     }
@@ -46,13 +43,12 @@ void genSq_drwGrid(){
 
 void genSq_drwCursor(byte s){
   int inst=genSq_actInst;
-  float color[3] = {0.25,0.25,0.25};
   if(genSq_clk[inst][s]>=0){
     for(int c=0;c<3;c++){
       for(int f=0;f<genSq_maxVisSteps;f++){
         genSq_crsrPix[s][f][c]=0;
       }    
-      genSq_crsrPix[s][genSq_clk[inst][s]][c]=color[c];
+      genSq_crsrPix[s][genSq_clk[inst][s]][c]=genSq_cursorColor[c];
     }
   }
 }
@@ -77,8 +73,9 @@ void genSq_drwStep(byte s){
     for(int c=0;c<3;c++){
       genSq_stpPix[s][f][c]=0;    
       if((genSq_stpOnOff[inst][pttn][s][f]>0 && f>=off && f<nSteps+off) || f<off+nSteps-genSq_maxVisSteps){
-        if(chnl>0)genSq_stpPix[s][f][c]=tnClrs[pitch][c]*brght;
-        if(chnl==0)genSq_stpPix[s][f][c]=brght/2;
+        if(genSq_muteCh[inst][s]==1)genSq_stpPix[s][f][c]=genSq_stepMuteColor[c]*brght;
+        else if(chnl>0)genSq_stpPix[s][f][c]=tnClrs[pitch][c]*brght;
+        else if(chnl==0)genSq_stpPix[s][f][c]=genSq_stepNoChannelColor[c]*brght;
       }
       if(genSq_stpOnOff[inst][pttn][s][f]==0){
         genSq_stpPix[s][f][c]=0;

--- a/software/firmwareCtl/firmwareCtl.ino
+++ b/software/firmwareCtl/firmwareCtl.ino
@@ -347,13 +347,28 @@ const int chipSelect = BUILTIN_SDCARD;
   bool genSq_stpEdtStrs[nStrings];
   int genSq_stpEdtFrt;
 
+  //fequencer colors
+  const float strArp_gridColorA[3]={0.5,0,0};
+  const float strArp_gridColorB[3]={0.05,0,0};
+  const float strArp_gridMuteColorA[3]={0.1,0,0};
+  const float strArp_gridMuteColorB[3]={0.02,0,0};
+  const float strArp_cursorColor[3]={0,1,0};
+  const float strArp_stepColor[3]={1,0,1};
+  const float strArp_stepMuteColor[3]={0.2,0.2,0.2};
+  const float genSq_gridColorA[genSq_nInst][3]={{0.0,0.25,0.25},{0.375,0.0,0.25},{0.375,0.25,0.0}};
+  const float genSq_gridColorB[genSq_nInst][3]={{0.0,0.05,0.05},{0.075,0.0,0.05},{0.075,0.05,0.0}};
+  const float genSq_gridMuteColorA[genSq_nInst][3]={{0.0,0.025,0.025},{0.0375,0.0,0.025},{0.0375,0.025,0.0}};
+  const float genSq_gridMuteColorB[genSq_nInst][3]={{0.0,0.005,0.005},{0.0075,0.0,0.005},{0.0075,0.005,0.0}};
+  const float genSq_cursorColor[3]={0.25,0.25,0.25};
+  const float genSq_stepNoChannelColor[3]={0.5,0.5,0.5};
+  const float genSq_stepMuteColor[3]={0.2,0.2,0.2};
+
   float genSq_edtPttnColor[3]={0.0,0.0,0.1};
 
   // GenSeq per-instance runtime state lives in genSeqRuntime.
   // GenSeq per-pattern step/channel data lives in genSeqPatterns.
   // Compatibility macros above keep existing index order unchanged.
   //int genSq_sndCh[genSq_nInst][nStrings]={{1,1,1,1,1,1},{2,2,2,2,2,2},{3,3,3,3,3,3}};
-  float genSq_gridColor[genSq_nInst][3]={{0.0,0.01,0.01},{0.015,0.0,0.01},{0.015,0.01,0.0}};
 
 // String Sequencer (from genSeq)
   bool strSeq_act=1;


### PR DESCRIPTION
### Motivation
- Replace scattered hardcoded color literals with centralized, named color constants to make LED color tuning and per-mode/mute behavior easier to manage. 
- Provide distinct A/B brightness variants and explicit mute/cursor/step colors so visual behavior is consistent across sequencer and arpeggiator code paths.

### Description
- Added new color constant arrays to `firmwareCtl.ino` for string-arpeggiator and gen-sequencer usage including `strArp_gridColorA`, `strArp_gridColorB`, `strArp_gridMuteColorA`, `strArp_gridMuteColorB`, `strArp_cursorColor`, `strArp_stepColor`, `strArp_stepMuteColor`, `genSq_gridColorA`, `genSq_gridColorB`, `genSq_gridMuteColorA`, `genSq_gridMuteColorB`, `genSq_cursorColor`, `genSq_stepNoChannelColor`, and `genSq_stepMuteColor`.
- Replaced local hardcoded color arrays in `09_op02_StrArp.ino` with the new `strArp_*` constants for grid, cursor, and step rendering.
- Replaced local hardcoded color and mute-dimming logic in `10_op_genSq_Disp.ino` and `05_ledfrets.ino` with the new `genSq_*` constants and switched mute handling to use explicit mute color palettes instead of multiplying target colors by a scalar.
- Removed several now-unused local color variables and consolidated color selection logic so per-instance and per-channel visual styles come from the shared constants.

### Testing
- Performed a full firmware build using the project build pipeline (`arduino-cli compile` used in CI) and the build completed successfully with no compile errors. 
- No automated unit tests are present for LED visuals, so runtime visual verification is expected on target hardware during manual testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b4715b9f083329ca4e062eb9be4ac)