### PR TITLE
Align serial arpeggiator clock when first step is added to an empty sequence

### DIFF
--- a/software/firmwareCtl/09_op02_StrArp.ino
+++ b/software/firmwareCtl/09_op02_StrArp.ino
@@ -71,7 +71,18 @@ void strArp_ersStps(){
 
 void strArp_updClck(){
   if(strArp_act == 1){  
+    bool strArp_wasEmpty=strArp_seqLen==0;
     strArp_mkArp();
+
+    if(strArp_wasEmpty && strArp_seqLen>0){
+      byte firstString=strArp_seq[0];
+      byte firstDuration=strArp_tmDv[firstString];
+      if(firstDuration>0){
+        long clockPhase=mClock%firstDuration;
+        if(clockPhase<0)clockPhase+=firstDuration;
+        strArp_serialNxtClkFil=clockPhase==0 ? firstDuration-1 : clockPhase-1;
+      }
+    }
 
     strArp_updClckSerial();
     strArp_drwGrid();


### PR DESCRIPTION
### Motivation
- Prevent misalignment or immediate triggering of the serial arpeggiator when the first step is added to a previously empty sequence by aligning the serial clock fill with the master clock phase.

### Description
- Detect the transition from an empty to a non-empty sequence in `strArp_updClck()` using `strArp_seqLen` and a `strArp_wasEmpty` flag.
- Compute `clockPhase = mClock % firstDuration` for the first string's duration and set `strArp_serialNxtClkFil` to `clockPhase==0 ? firstDuration-1 : clockPhase-1` so the serial sequencer's next fill is phase-aligned with the master clock.
- Leave existing reset behavior in `strArp_resetSerialCursor()` intact and keep the rest of the clock/draw flow unchanged.

### Testing
- Built the firmware (`arduino-cli`/`platformio` compile) with no compile errors.  
- Ran an automated clock-phase simulation test verifying that adding the first step sets `strArp_serialNxtClkFil` to align the first note with `mClock`, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71de82c05c8332abf4a41b9fbc5f9b)