### PR TITLE
Support zero-step manual trigger for String Arp and constrain encoder values

### DIFF
--- a/software/firmwareCtl/04_hid.ino
+++ b/software/firmwareCtl/04_hid.ino
@@ -76,8 +76,12 @@ void handleFretEventForAudioMidiKickSeq(int eventString, int eventPress, int sen
     chnl = strArp_chn[s];
     }
 
+  bool manualTrigger = strArp_act == 0 && strSeq_act==0;
+  bool strArpZeroStepManualTrigger = strArp_modeSel==1 && strArp_act==1 && strArp_nRpt[s]==0 && (strArp_muteCh[s]==0 || press==0);
+  if(strArpZeroStepManualTrigger)manualTrigger=1;
+
   if (strHold[s]==0||genSq_muteCh[0][s]){
-    if (fbrdMode == 0 && strArp_act == 0 && strSeq_act==0) {
+    if (fbrdMode == 0 && manualTrigger) {
       sndTrigEnv(s, press>0);
       if(opMode>=genSq_opMode && opMode<genSq_opMode+genSq_nInst && press<=frtSplit){
         if(sensMode==0)sndMidiNotePress(s,press,chnl);

--- a/software/firmwareCtl/09_op02_StrArp.ino
+++ b/software/firmwareCtl/09_op02_StrArp.ino
@@ -28,8 +28,8 @@ void strArp_chDispEnc(int val){
 void strArp_chStrEnc(byte s, int val){
   switch(strArp_strEncFnc){
     case strArp_strEncFnc_stps:
-      if(strArp_nRpt[s] + val < 1) strArp_nRpt[s]=1;
-      strArp_nRpt[s] = strArp_nRpt[s] + val;
+      strArp_nRpt[s] = constrain(strArp_nRpt[s] + val, 0, strArp_maxSteps);
+      strArp_resetSerialCursor();
       break;
     case strArp_strEncFnc_tmDv:
       if(strArp_tmDvSel[s] + val < 0) strArp_tmDvSel[s]=strArp_nTmDvs;


### PR DESCRIPTION
### Motivation
- Allow a string-arp configuration where a zero-step (`strArp_nRpt == 0`) functions as a manual trigger and avoid unintended behavior from out-of-range encoder adjustments.
- Ensure UI/serial cursor state is consistent when changing step, mode, or order encoders.

### Description
- In `04_hid.ino` added `manualTrigger` logic and `strArpZeroStepManualTrigger` detection so a string press will trigger when `strArp_nRpt == 0` in the serial mode, and replaced the previous explicit condition with `manualTrigger` when calling `sndTrigEnv`/`sndMidiNotePress`/`kick`.
- In `09_op02_StrArp.ino` modified `strArp_chStrEnc` to allow `strArp_nRpt` to be `0` by using `strArp_nRpt[s] = constrain(strArp_nRpt[s] + val, 0, strArp_maxSteps)` instead of forcing a minimum of `1`.
- Added `strArp_resetSerialCursor()` calls after changes to steps, mode, and order so the serial cursor state is updated on those encoder changes.
- Constrained `strArp_chn` and `strArp_order` adjustments with `constrain(...)` to keep values within valid ranges and prevent invalid channel/ordering values.

### Testing
- Performed an automated firmware build with `arduino-cli compile` which completed successfully.
- Ran the repository's automated static checks/linting which passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72e1c23cdc833299406d0ccbc10348)