### PR TITLE
Add per-string manual envelope-decay override and protocol support (AUDIO_CMD_MANUAL_ENV)

### DIFF
--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -112,6 +112,7 @@ Known command IDs:
 | `207` | `7` | `sndEnv1(para, val)` | `byte para`, `byte scaledVal` | Audio scales `scaledVal / 199.0` with `sclEnvA[para]`, calls `chEnvA`. |
 | `208` | `8` | `sndEnv2(para, val)` | `byte para`, `byte scaledVal` | Audio scales `scaledVal / 199.0` with `sclEnvF[para]`, calls `chEnvF`. |
 | `209` | `9` | `sndFilter(para, val)` | `byte para`, `byte scaledVal` | Audio scales with `sclFilter[para]`, calls `chFilter`. |
+| `210` | `10` | `sndManualEnv(str, state)` | `byte str`, `byte state` | Audio stores per-string manual envelope-decay override; while enabled, amplitude and filter decay keep sustain high regardless of decay fader value. |
 | `211` | `11` | `sndVol(val)` | `byte scaledVal` | Audio computes `(scaledVal / 199.0)^2 * 2`, then `ampOut.gain(val + 0.0001)`. |
 | `212` | `12` | `sndStrGain(str, val)` | `byte str`, `byte scaledVal` | Audio computes `scaledVal / 100.0`, calls `chngStrOutGain`. CTL sends `val * 2`. |
 | `215` | `15` | not found in CTL sender file | `byte para`, `byte scaledVal` | Audio scales with `sclFX[para]`, calls `chFX`. Source uncertain. |

--- a/software/firmwareAudio/ProtocolAudio.h
+++ b/software/firmwareAudio/ProtocolAudio.h
@@ -16,6 +16,7 @@ constexpr byte AUDIO_CMD_BOW_ON = 206;
 constexpr byte AUDIO_CMD_ENV_1 = 207;
 constexpr byte AUDIO_CMD_ENV_2 = 208;
 constexpr byte AUDIO_CMD_FILTER = 209;
+constexpr byte AUDIO_CMD_MANUAL_ENV = 210;
 constexpr byte AUDIO_CMD_VOLUME = 211;
 constexpr byte AUDIO_CMD_STR_GAIN = 212;
 constexpr byte AUDIO_CMD_FX = 215;

--- a/software/firmwareAudio/envelopes.ino
+++ b/software/firmwareAudio/envelopes.ino
@@ -1,3 +1,22 @@
+void applyAmpDecayForString(byte str, float val){
+  aEnv[str].decay(val);
+  if (manualEnvDecay[str] || val >= (sclEnvA[3] / 20.0 * 19)) aEnv[str].sustain(1);
+  else aEnv[str].sustain(0);
+}
+
+void applyFilterDecayForString(byte str, float val){
+  fEnv[str].decay(val);
+  if (manualEnvDecay[str] || val >= (sclEnvF[3] / 20.0 * 19)) fEnv[str].sustain(1);
+  else fEnv[str].sustain(0);
+}
+
+void chManualEnvDecay(byte str, byte state){
+  if (str >= nStrings) return;
+  manualEnvDecay[str] = state > 0;
+  applyAmpDecayForString(str, envPA[3]);
+  applyFilterDecayForString(str, envPF[3]);
+}
+
 void chEnvA(byte para, float val){
  //if (msg.isFloat(0)){
   
@@ -6,11 +25,7 @@ void chEnvA(byte para, float val){
     if(para==0)aEnv[i].delay(val);
     if(para==1)aEnv[i].attack(val);
     if(para==2)aEnv[i].hold(val);
-    if(para==3){
-      aEnv[i].decay(val);
-      if (val>=(sclEnvA[para]/20.0*19))aEnv[i].sustain(1);
-      else aEnv[i].sustain(0);
-    }
+    if(para==3)applyAmpDecayForString(i, val);
     if(para==4)aEnv[i].sustain(val);
     if(para==5)aEnv[i].release(val);
     if(para==6){
@@ -28,11 +43,7 @@ void chEnvF(byte para, float val){
     if(para==0)fEnv[i].delay(val);
     if(para==1)fEnv[i].attack(val);
     if(para==2)fEnv[i].hold(val);
-    if(para==3){
-      fEnv[i].decay(val);
-      if (val>=(sclEnvF[para]/20.0*19))fEnv[i].sustain(1);
-      else fEnv[i].sustain(0);   
-    }
+    if(para==3)applyFilterDecayForString(i, val);
     if(para==4)fEnv[i].sustain(val);
     if(para==5)fEnv[i].release(val);
     if(para==6){

--- a/software/firmwareAudio/firmwareAudio.ino
+++ b/software/firmwareAudio/firmwareAudio.ino
@@ -73,6 +73,7 @@ float sclEnvF[7]={50,1000,300,5000,1,300,1};
 
 byte strState[nStrings]={0,0,0,0,0,0};
 byte lastStrState[nStrings]={0,0,0,0,0,0};
+byte manualEnvDecay[nStrings]={0,0,0,0,0,0};
 
 byte noteState[128];
 byte lastNoteState[128];

--- a/software/firmwareAudio/yLoop.ino
+++ b/software/firmwareAudio/yLoop.ino
@@ -18,6 +18,7 @@ byte audioCommandPayloadLength(byte command) {
     case AUDIO_CMD_ENV_1: return 2;
     case AUDIO_CMD_ENV_2: return 2;
     case AUDIO_CMD_FILTER: return 2;
+    case AUDIO_CMD_MANUAL_ENV: return 2;
     case AUDIO_CMD_VOLUME: return 1;
     case AUDIO_CMD_STR_GAIN: return 2;
     case AUDIO_CMD_FX: return 2;
@@ -56,6 +57,10 @@ void handleAudioSerialPacket(byte command, const byte payload[]) {
     float sclVal = scale(payload[1] / 199.0, 1, sclEnvF[payload[0]]);
     chEnvF(payload[0], sclVal);
     envPF[payload[0]] = sclVal;
+  }
+
+  if (incoming == audioIncoming(AUDIO_CMD_MANUAL_ENV)) {
+    chManualEnvDecay(payload[0], payload[1]);
   }
 
   if (incoming == audioIncoming(AUDIO_CMD_FILTER)) {

--- a/software/firmwareCtl/04_hid.ino
+++ b/software/firmwareCtl/04_hid.ino
@@ -64,6 +64,19 @@ bool emitFretEvents(int *eventString, int *eventPress) {
   return 0;
 }
 
+bool stringHasManualEnvelopeDecay(int stringIndex, int press) {
+  bool manualTrigger = strArp_act == 0 && strSeq_act == 0;
+  bool strArpZeroStepManualTrigger = strArp_modeSel == 1 && strArp_act == 1 && strArp_nRpt[stringIndex] == 0 && (strArp_muteCh[stringIndex] == 0 || press == 0);
+  if (strArpZeroStepManualTrigger) manualTrigger = 1;
+  return fbrdMode == 0 && manualTrigger && press > 0;
+}
+
+void sendManualEnvelopeStateForPressedStrings() {
+  for (int s = 0; s < nStrings; s++) {
+    sndManualEnv(s, stringHasManualEnvelopeDecay(s, strPrs[s]));
+  }
+}
+
 void handleFretEventForAudioMidiKickSeq(int eventString, int eventPress, int sensMode) {
   int s = eventString;
   int press = eventPress;
@@ -79,6 +92,7 @@ void handleFretEventForAudioMidiKickSeq(int eventString, int eventPress, int sen
   bool manualTrigger = strArp_act == 0 && strSeq_act==0;
   bool strArpZeroStepManualTrigger = strArp_modeSel==1 && strArp_act==1 && strArp_nRpt[s]==0 && (strArp_muteCh[s]==0 || press==0);
   if(strArpZeroStepManualTrigger)manualTrigger=1;
+  sndManualEnv(s, stringHasManualEnvelopeDecay(s, press));
 
   if (strHold[s]==0||genSq_muteCh[0][s]){
     if (fbrdMode == 0 && manualTrigger) {
@@ -146,6 +160,7 @@ void procHidDChng(byte idx, bool val) {
       //tripple switch left
       strSeq_act = val && !strArp_modeSel;
       strArp_act = val && strArp_modeSel;
+      sendManualEnvelopeStateForPressedStrings();
       break;
 
     case 3:

--- a/software/firmwareCtl/2audio.ino
+++ b/software/firmwareCtl/2audio.ino
@@ -21,6 +21,12 @@ void sndStrGain(int str, byte val) {
 //  msgOut_audio.streamPacket(&Serial1);
 }
 
+void sndManualEnv(byte str, byte state){
+  Serial1.write(AUDIO_CMD_MANUAL_ENV);
+  Serial1.write(str);
+  Serial1.write(state);
+}
+
 void sndVol(float val){
   Serial1.write(AUDIO_CMD_VOLUME);
   Serial1.write(byte(val*125)); //lowered to avoid clipping

--- a/software/firmwareCtl/ProtocolAudio.h
+++ b/software/firmwareCtl/ProtocolAudio.h
@@ -16,6 +16,7 @@ constexpr byte AUDIO_CMD_BOW_ON = 206;
 constexpr byte AUDIO_CMD_ENV_1 = 207;
 constexpr byte AUDIO_CMD_ENV_2 = 208;
 constexpr byte AUDIO_CMD_FILTER = 209;
+constexpr byte AUDIO_CMD_MANUAL_ENV = 210;
 constexpr byte AUDIO_CMD_VOLUME = 211;
 constexpr byte AUDIO_CMD_STR_GAIN = 212;
 constexpr byte AUDIO_CMD_FX = 215;


### PR DESCRIPTION
### Motivation

- Introduce a per-string "manual envelope decay" override so amplitude and filter envelopes can be held to sustain when a manual trigger/playing mode is active.  
- Expose this state over the CTL<->Audio serial protocol so the controller can enable/disable the manual decay on individual strings in real time.

### Description

- Add `AUDIO_CMD_MANUAL_ENV = 210` to `ProtocolAudio.h` in both `firmwareAudio` and `firmwareCtl` so CTL can send manual-env state to Audio.  
- Implement `sndManualEnv(byte str, byte state)` in `software/firmwareCtl/2audio.ino` and add payload length handling for the new command in `software/firmwareAudio/yLoop.ino`.  
- Send manual-env updates from the controller by adding `stringHasManualEnvelopeDecay` and `sendManualEnvelopeStateForPressedStrings` and invoking `sndManualEnv` from fret handling and mode switch code in `software/firmwareCtl/04_hid.ino`.  
- Audio-side: add `manualEnvDecay[]`, `applyAmpDecayForString`, `applyFilterDecayForString`, and `chManualEnvDecay` in `software/firmwareAudio/envelopes.ino`, and update `chEnvA`/`chEnvF` to use the new apply functions, plus handle the new command in `yLoop.ino` to call `chManualEnvDecay`.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72eb279a6c83329ae08fd4aaf6c250)